### PR TITLE
one char fix in R file removing spurious ':'

### DIFF
--- a/R/session.R
+++ b/R/session.R
@@ -6,7 +6,7 @@
 #'
 #' @param target Optional. The execution engine to connect to. Defaults to using
 #'   an in-process engine.
-#' @param graph: Optional. The Graph to be launched (described below).
+#' @param graph Optional. The Graph to be launched (described below).
 #' @param config (Optional.) A list with configuration options for the session.
 #'
 #' @details

--- a/man/session.Rd
+++ b/man/session.Rd
@@ -10,9 +10,9 @@ session(target = "", graph = NULL, config = NULL)
 \item{target}{Optional. The execution engine to connect to. Defaults to using
 an in-process engine.}
 
-\item{config}{(Optional.) A list with configuration options for the session.}
+\item{graph}{Optional. The Graph to be launched (described below).}
 
-\item{graph:}{Optional. The Graph to be launched (described below).}
+\item{config}{(Optional.) A list with configuration options for the session.}
 }
 \description{
 A Session object encapsulates the environment in which Operation objects are


### PR DESCRIPTION
It's trivial but I do run 'R CMD check' (via a littler script calling Gabor's nice function `rcmdcheck::rcmdcheck()`) and this suppresses almost ten lines of noise.  It was just a typo on your end.
