### PR TITLE
Fixes #16: Setup CI for linux and osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+sudo: true
+
+language: cpp
+
+os:
+  - linux
+  - osx
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - wget
+      - libatlas3gf-base
+      - libatlas-dev
+      - python-joblib
+
+install:
+  - source travis_install.sh
+
+script:
+  - source run_tests.sh
+
+cache:
+  directories:
+    - ${HOME}/.cache/usr
+
+notifications:
+  email:
+    on_success: change
+    on_failure: always

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-Rscript -e "library(tensorflow)"
+Rscript -e 'Sys.setenv(TENSORFLOW_PYTHON=system("which python", intern = T));library(tensorflow)'

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "SUCCESS"

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "SUCCESS"
+Rscript -e "library(tensorflow)"

--- a/travis_install.sh
+++ b/travis_install.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# create virtualenv
+deactivate
+virtualenv --system-site-packages testenv
+source testenv/bin/activate
+
+# Python dependencies
+sudo pip install --upgrade pip
+sudo pip install numpy
+# tensorflow for separate os
+if [ ${TRAVIS_OS_NAME} == "linux" ]; then
+  sudo pip install https://ci.tensorflow.org/view/Nightly/job/nightly-matrix-cpu/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON2,label=cpu-slave/lastSuccessfulBuild/artifact/pip_test/whl/tensorflow-0.10.0-cp27-none-linux_x86_64.whl
+fi
+if [ ${TRAVIS_OS_NAME} == "osx" ]; then
+  sudo pip install https://ci.tensorflow.org/view/Nightly/job/nightly-matrix-cpu/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON2,label=mac1-slave/lastSuccessfulBuild/artifact/pip_test/whl/tensorflow-0.10.0-py2-none-any.whl
+fi
+
+# R dependencies
+curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
+chmod 755 ./travis-tool.sh
+./travis-tool.sh bootstrap
+./travis-tool.sh install_aptget r-cran-testthat r-cran-devtools r-cran-rcpp
+./travis-tool.sh install_deps
+Rscript -e 'devtools::install_github("rstudio/tensorflow")'


### PR DESCRIPTION
Just had a chance to quickly spin this up. I know `r-travis` is deprecated but I don't have too much time switching to use native R support in Travis at this moment. 