### PR TITLE
S3 method fix and added CITATION file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: required
 
 language: r
+warnings_are_errors: false
 
 os:
   - linux
@@ -32,4 +33,4 @@ notifications:
 
 env:
   - TENSORFLOW_TEST_EXAMPLES="1"
-    R_GCTORTURE="25"  
+    R_GCTORTURE="25"

--- a/R/python.R
+++ b/R/python.R
@@ -97,6 +97,7 @@ str.tensorflow.builtin.object <- function(object, ...) {
 
 #' @importFrom utils .DollarNames
 #' @export
+#' @method .DollarNames tensorflow.builtin.object
 .DollarNames.tensorflow.builtin.object <- function(x, pattern = "") {
 
   # skip if this is a NULL xptr

--- a/R/tf_generics.R
+++ b/R/tf_generics.R
@@ -34,6 +34,7 @@ str.tensorflow.python.ops.variables.Variable <- function(object, ...) {
 print.tensorflow.python.ops.variables.Variable <- print.tensorflow.python.framework.ops.Tensor
 
 #' @export
+#' @method .DollarNames tensorflow.python.platform.flags._FlagValues
 .DollarNames.tensorflow.python.platform.flags._FlagValues <- function(x, pattern = "") {
 
   # skip if this is a NULL xptr

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,0 +1,9 @@
+citHeader("To cite tensorflow in publications, please use:")
+
+citEntry(entry = "manual",
+  author = "JJ Allaire, Dirk Eddelbuettel, Nick Golding, and Yuan Tang",
+  title = "tensorflow: R Interface to TensorFlow",
+  year = "2016",
+  url = "https://github.com/rstudio/tensorflow",
+  textVersion = "JJ Allaire, Dirk Eddelbuettel, Nick Golding, and Yuan Tang (2016). tensorflow: R Interface to TensorFlow. https://github.com/rstudio/tensorflow"
+)


### PR DESCRIPTION
Roxygen generates wrong items in NAMESPACE if S3 method is not specified explicitly:

Instead of this:
```
S3method(.DollarNames,tensorflow.builtin.object)
S3method(.DollarNames,tensorflow.python.platform.flags._FlagValues)
```

It generates this:
```
export(.DollarNames.tensorflow.builtin.object)
export(.DollarNames.tensorflow.python.platform.flags._FlagValues)
```

