### PR TITLE
TFLearn DNNClassifier examples

### DIFF
--- a/inst/examples/tflearn/README.md
+++ b/inst/examples/tflearn/README.md
@@ -1,0 +1,3 @@
+# Examples using TF.Learn
+
+This directory provides basic examples of TF.Learn to get you started in building deep learning or machine learning models quickly in TensorFlow R. More tutorials in Python can be found [here](https://www.tensorflow.org/versions/master/tutorials/tflearn/index.html#tf-contrib-learn-quickstart) and [here](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/examples/learn). You can mimic those Python examples to write your R program. 

--- a/inst/examples/tflearn/iris_dnn.R
+++ b/inst/examples/tflearn/iris_dnn.R
@@ -18,7 +18,7 @@ classifier <- tf$contrib$learn$DNNClassifier(
   model_dir = temp_model_dir)
 
 # Train a DNN Classifier
-classifier$fit(datasets$data[train_inds, ], datasets$target[train_inds], steps = 200)
+classifier$fit(datasets$data[train_inds, ], datasets$target[train_inds], steps = 100)
 
 # Generate predictiosn on new data
 predictions <- classifier$predict(datasets$data[test_inds, ])

--- a/inst/examples/tflearn/iris_dnn.R
+++ b/inst/examples/tflearn/iris_dnn.R
@@ -1,0 +1,7 @@
+library(tensorflow)
+
+
+datasets <- tf$contrib$learn$datasets$load_dataset("iris")
+feature_columns <- tf$contrib$learn$infer_real_valued_columns_from_input(datasets$data)
+classifier <- tf$contrib$learn$DNNClassifier(feature_columns = feature_columns, hidden_units = c(10, 20, 10), n_classes = 3)
+classifier$fit(datasets$data, datasets$target, steps = 100)

--- a/inst/examples/tflearn/iris_dnn.R
+++ b/inst/examples/tflearn/iris_dnn.R
@@ -1,7 +1,26 @@
 library(tensorflow)
 
+train_inds <- 1:100
+test_inds <- 100:150
+
+temp_model_dir <- tempdir()
 
 datasets <- tf$contrib$learn$datasets$load_dataset("iris")
+
+# Infer the real-valued feature columns
 feature_columns <- tf$contrib$learn$infer_real_valued_columns_from_input(datasets$data)
-classifier <- tf$contrib$learn$DNNClassifier(feature_columns = feature_columns, hidden_units = c(10, 20, 10), n_classes = 3)
-classifier$fit(datasets$data, datasets$target, steps = 100)
+
+# Initialize a DNN classifier with hidden units 10, 15, 10 in each layer
+classifier <- tf$contrib$learn$DNNClassifier(
+  feature_columns = feature_columns,
+  hidden_units = c(10L, 15L, 10L),
+  n_classes = 3L,
+  model_dir = temp_model_dir)
+
+# Train a DNN Classifier
+classifier$fit(datasets$data[train_inds, ], datasets$target[train_inds], steps = 200)
+
+# Generate predictiosn on new data
+predictions <- classifier$predict(datasets$data[test_inds, ])
+accuracy <- sum(predictions == datasets$target[test_inds]) / length(predictions)
+print(paste0("The accuracy is ", accuracy))


### PR DESCRIPTION
Couple issues noticed:

- hidden_units = c(10L, 15L, 10L) if `L` is not specified, you'll see 
```
Error in py_call(attrib, args, keywords) : 
  ValueError: ('num_outputs should be int or long, got %s.', 10.0)
```
This is caused when `hidden_units` are not of `six.interger_types` in Python, 
```
>>> six.integer_types
(<type 'int'>, <type 'long'>)
```

- My first run of this gives me good accuracy but the runs after give me accuracy like 0.0196 and it's always the same number. This happens even when I re-open my RStudio and even when I change `temp_model_dir`. 

