### PR TITLE
Added tracebacks in py error messages

### DIFF
--- a/src/python.cpp
+++ b/src/python.cpp
@@ -226,6 +226,10 @@ std::string py_fetch_error() {
       PyObjectPtr pStr(::PyObject_Str(pExcValue));
       ostr << as_std_string(pStr);
     }
+    if (!pExcTraceback.is_null()) {
+      PyObjectPtr pStr(::PyObject_Str(pExcTraceback));
+      ostr << "Detailed trackback: " << as_std_string(pStr);
+    }
     error = ostr.str();
   } else {
     error = "<unknown error>";


### PR DESCRIPTION
For more detailed error messages, e.g. the following message could at least tell you the shape does not match between the model you are building and the model saved previously. 

```
Error in py_call(attrib, args, keywords) : 
  InvalidArgumentError: Shape in shape_and_slice spec does not match the shape in the save file: [11,3], save file shape: [10,3]
	 [[Node: save/restore_slice_23 = RestoreSlice[dt=DT_FLOAT, preferred_shard=0, _device="/job:localhost/replica:0/task:0/cpu:0"](_recv_save/Const_0, save/restore_slice_23/tensor_name, save/restore_slice_23/shape_and_slice)]]

Caused by op u'save/restore_slice_23', defined at:
  File "/usr/local/opt/python/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/tensorflow/contrib/learn/python/learn/estimators/dnn.py", line 435, in fit
    max_steps=max_steps)
  File "/usr/local/opt/python/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/tensorflow/contrib/learn/python/learn/estimators/estimator.py", line 333, in fit
    max_steps=max_steps)
  File "/usr/local/opt/python/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/tensorflow/contrib/learn/python/learn/estimators/estimator.py", line 708, in _train_
```

Originally, it was very obscure:
```
Error in py_call(attrib, args, keywords) : basic_string::_M_replace_aux
```

Issue reported in https://github.com/rstudio/tensorflow/pull/40