### PR TITLE
Fix edge case for iterator/generator conversion

### DIFF
--- a/R/python.R
+++ b/R/python.R
@@ -234,7 +234,8 @@ with.tensorflow.builtin.object <- function(data, expr, as = NULL, ...) {
 iterate <- function(x, f = base::identity) {
   if (!inherits(x, "tensorflow.builtin.iterator"))
     stop("iterate function called with non-iterator argument")
-  invisible(py_iterate(x, f))
+  invisible(result <- py_iterate(x, f))
+  return(result)
 }
 
 #' @export

--- a/tests/testthat/test-python-iterators.R
+++ b/tests/testthat/test-python-iterators.R
@@ -11,4 +11,9 @@ test_that("Iterators reflect values back", {
 
 test_that("Generators reflect values back", {
   expect_equal(as.integer(iterate(test$makeGenerator(5))) + 1L, seq(5))
+  a <- test$makeGenerator(5)
+  b <- as.integer(iterate(a))
+  expect_equal(b + 1L, seq(5))
 })
+
+

--- a/tests/testthat/test-python-iterators.R
+++ b/tests/testthat/test-python-iterators.R
@@ -6,11 +6,15 @@ test <- import("tftools.test")
 test_that("Iterators reflect values back", {
   rlist <- list("foo", "bar", 42L)
   expect_equal(iterate(test$makeIterator(rlist)), rlist)
+  a <- test$makeIterator(rlist)
+  b <- iterate(a)
+  expect_equal(b, rlist)
 })
 
 
 test_that("Generators reflect values back", {
   expect_equal(as.integer(iterate(test$makeGenerator(5))) + 1L, seq(5))
+  # Test iterate() returns
   a <- test$makeGenerator(5)
   b <- as.integer(iterate(a))
   expect_equal(b + 1L, seq(5))


### PR DESCRIPTION
Fixed the following edge case:

This works
```
test <- import("tftools.test")
> as.integer(iterate(test$makeGenerator(5)))
[1] 0 1 2 3 4
```
But this doesn't
```
test <- import("tftools.test")
> a <- test$makeGenerator(5)
> a
<generator object makeGenerator at 0x119ae6050>
Python iterator/generator (use tensorflow::iterate to traverse)
> b <- iterate(a)
> b
list()
```