### PR TITLE
Point to tf.learn example folder in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ sess$run(hello)
 
 ## Documentation
 
+We recommend users to try out TensorFlow's high-level [TF.Learn module](https://arxiv.org/abs/1612.04251) to minimize efforts of learning low-level TensorFlow API. Some basic examples can be found [here](https://github.com/rstudio/tensorflow/tree/master/inst/examples/tflearn).
+
 See the package website for additional details on using the TensorFlow API from R: <https://rstudio.github.io/tensorflow>
 
 See the TensorFlow API reference for details on all of the modules, classes, and functions within the API: <https://www.tensorflow.org/api_docs/python/index.html>


### PR DESCRIPTION
Just add some minimal pointer for now. In the future, we may need some tutorials on the website. 