### PR TITLE
Travis script improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: required
+sudo: false
 
 language: r
 warnings_are_errors: false
@@ -7,29 +7,33 @@ os:
   - linux
   - osx
 
-dist: trusty
-
-cache: packages
+cache:
+  packages: true
+  directories:
+    - $HOME/.cache/pip
 
 before_install:
-  - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
+  - export PATH=$(perl -e 'print join(":", grep { !m{/opt/python/} } split /:/, $ENV{PATH})')
   - source travis_install.sh
 
-apt_packages:
-  - libmagick++-dev
-  - wget
-  - libatlas3gf-base
-  - libatlas-dev
-  - python-joblib
-  - libpython-dev
+addons:
+  apt:
+    sources:
+      ubuntu-toolchain-r-test
+    packages:
+      - libmagick++-dev
+      - wget
+      - libatlas3gf-base
+      - libatlas-dev
+      - python-joblib
+      - python-dev
 
-r_packages:
-  - testthat
+script: -|
+  R CMD build .
+  travis_wait 30 R CMD check tenserflow*tar.gz
 
-notifications:
-  email:
-    on_success: change
-    on_failure: always 
+after_failure:
+  find *Rcheck -name '*.fail' -print -exec cat '{}' \;
 
 env:
   - TENSORFLOW_TEST_EXAMPLES="1"

--- a/travis_install.sh
+++ b/travis_install.sh
@@ -1,18 +1,14 @@
 #!/bin/bash
-
-# create virtualenv
-deactivate
-virtualenv --system-site-packages testenv
-source testenv/bin/activate
+set -e
 
 # Python dependencies
-sudo pip install --upgrade pip
-sudo pip install numpy
+pip install --upgrade pip --user
+pip install numpy --user
+
 # tensorflow for separate os
 if [ ${TRAVIS_OS_NAME} == "linux" ]; then
-  sudo pip install https://ci.tensorflow.org/view/Nightly/job/nightly-matrix-cpu/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON2,label=cpu-slave/lastSuccessfulBuild/artifact/pip_test/whl/tensorflow-0.10.0-cp27-none-linux_x86_64.whl
+  pip install --user https://ci.tensorflow.org/view/Nightly/job/nightly-matrix-cpu/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON2,label=cpu-slave/lastSuccessfulBuild/artifact/pip_test/whl/tensorflow-0.12.1-cp27-none-linux_x86_64.whl
 fi
 if [ ${TRAVIS_OS_NAME} == "osx" ]; then
-  sudo pip install https://ci.tensorflow.org/view/Nightly/job/nightly-matrix-cpu/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON2,label=mac1-slave/lastSuccessfulBuild/artifact/pip_test/whl/tensorflow-0.10.0-py2-none-any.whl
+  pip install --user https://ci.tensorflow.org/view/Nightly/job/nightly-matrix-cpu/TF_BUILD_IS_OPT=OPT,TF_BUILD_IS_PIP=PIP,TF_BUILD_PYTHON_VERSION=PYTHON2,label=mac-slave/lastSuccessfulBuild/artifact/pip_test/whl/tensorflow-0.12.1-py2-none-any.whl
 fi
-


### PR DESCRIPTION
A few improvements that should improve the travis script robustness and improve
execution time.

- Use `travis_wait` when running R CMD check. The OS X builds are often
failing due to a timeout. Using `travis_wait` will work around this issue
by generating output periodically, so the builds should complete.

- Use `sudo: false` and precise builds.

This will enable use of the container based infrastructure, which should
result in faster build times. Use of precise rather than trusty means
the dependencies will be earlier versions, but this may also ensure the
package works with more systems. Using `--user` for the pip calls should
also remove the warnings about invalid permissions
(https://travis-ci.org/rstudio/tensorflow/jobs/186765420#L749)

- Cache the pip dependencies as well as R dependencies.
Should speed up builds a decent amount.

- Rewrite the PATH splitting code

The current implementation uses 4 different processes and needs to use
workarounds to handle newlines, I think it is simpler to handle the path
properly in a scripting language. This commit uses perl, however if R or
python would be preferred equivalent implementations are.

    export PATH=$(Rscript -e 'cat(sep = ":", grep(invert = T, value = T, "/opt/python/", strsplit(Sys.getenv("PATH"), ":")[[1]]))')

    export PATH=$(python -c 'import os;import re;print ":".join(filter(lambda x:not re.search(r"/opt/python/", x), os.getenv("PATH").split(":")))')

- Fail the travis_install.sh script if any commands fail
Right now the travis build continues even when there are failures installing
tensorflow. Instead we set `set -e` which will fail the script, and
consequently the travis build if any of the commands fail.

- Update tenserflow URLs
The current URLs are returning a 404, this updates the URLs to the current version 0.12.1.

- Remove deactivate call
This currently always throws an error
https://travis-ci.org/rstudio/tensorflow/jobs/186765420#L746, as I
believe virtualenv is not yet installed when it is called.