### PR TITLE
Typo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ addons:
       - python-joblib
       - python-dev
 
-script: -|
+script: |-
   R CMD build .
   travis_wait 30 R CMD check tenserflow*tar.gz
 


### PR DESCRIPTION
My previous PR had a typo which caused the builds to fail, this should fix it, but I would wait until the builds finish successfully before merging.