### PR TITLE
automatically simplify results of iterate to vector when appropriate

### DIFF
--- a/docs/using_tensorflow_api.Rmd
+++ b/docs/using_tensorflow_api.Rmd
@@ -245,11 +245,13 @@ iterate(tf$python_io$tf_record_iterator(filename), function(record) {
 })
 ```
 
-If you just want to collect all of the items into an R list, you can call the `iterate` function with just the iterator and no function to apply:
+If you just want to collect all of the items into an R list or vector, you can call the `iterate` function with just the iterator and no function to apply:
 
 ```{r, eval=FALSE}
 records <- iterate(tf$python_io$tf_record_iterator(filename))
 ```
+
+The result will be automatically simplified to an R vector if all values returned from the iteration are length 1 vectors of single primitive type "character", "complex", "double", "integer", or "logical" (otherwise the result will be an R list).
 
 Note that Python iterators and generators are stateful objects. This means that after making a single pass through an iterator it will be empty (i.e. you can't execute another iteration against the same underlying iterator).
 

--- a/docs/using_tensorflow_api.html
+++ b/docs/using_tensorflow_api.html
@@ -672,8 +672,9 @@ W_smallish &lt;- W[, 7:9]</code></pre>
 <pre class="r"><code>iterate(tf$python_io$tf_record_iterator(filename), function(record) {
   # Process the record
 })</code></pre>
-<p>If you just want to collect all of the items into an R list, you can call the <code>iterate</code> function with just the iterator and no function to apply:</p>
+<p>If you just want to collect all of the items into an R list or vector, you can call the <code>iterate</code> function with just the iterator and no function to apply:</p>
 <pre class="r"><code>records &lt;- iterate(tf$python_io$tf_record_iterator(filename))</code></pre>
+<p>The result will be automatically simplified to an R vector if all values returned from the iteration are length 1 vectors of single primitive type “character”, “complex”, “double”, “integer”, or “logical” (otherwise the result will be an R list).</p>
 <p>Note that Python iterators and generators are stateful objects. This means that after making a single pass through an iterator it will be empty (i.e. you can’t execute another iteration against the same underlying iterator).</p>
 </div>
 <div id="getting-help" class="section level2">

--- a/inst/examples/tflearn/iris_custom_decay_dnn.R
+++ b/inst/examples/tflearn/iris_custom_decay_dnn.R
@@ -38,6 +38,6 @@ classifier$fit(datasets$data[train_inds, ], datasets$target[train_inds], steps =
 # Generate predictiosn on new data
 predictions <- classifier$predict(datasets$data[test_inds, ])
 # The predictions are iterators by default in Python API so we call iterate() to collect them
-predictions <- unlist(iterate(predictions))
+predictions <- iterate(predictions)
 accuracy <- sum(predictions == datasets$target[test_inds]) / length(predictions)
 print(paste0("The accuracy is ", accuracy))

--- a/inst/examples/tflearn/iris_dnn.R
+++ b/inst/examples/tflearn/iris_dnn.R
@@ -26,6 +26,6 @@ classifier$fit(datasets$data[train_inds, ], datasets$target[train_inds], steps =
 # Generate predictiosn on new data
 predictions <- classifier$predict(datasets$data[test_inds, ])
 # The predictions are iterators by default in Python API so we call iterate() to collect them
-predictions <- unlist(iterate(predictions))
+predictions <- iterate(predictions)
 accuracy <- sum(predictions == datasets$target[test_inds]) / length(predictions)
 print(paste0("The accuracy is ", accuracy))

--- a/man/iterate.Rd
+++ b/man/iterate.Rd
@@ -4,20 +4,26 @@
 \alias{iterate}
 \title{Traverse a Python iterator or generator}
 \usage{
-iterate(x, f = base::identity)
+iterate(x, f = base::identity, simplify = TRUE)
 }
 \arguments{
 \item{x}{Python iterator or generator}
 
-\item{f}{Function to apply to each item. By default applies
-the \code{identity} function which just reflects back the
-value of the item.}
+\item{f}{Function to apply to each item. By default applies the
+\code{identity} function which just reflects back the value of the item.}
+
+\item{simplify}{Should the result be simplified to a vector if possible?}
 }
 \value{
-List containing the results of calling \code{f} on each
- item in \code{x} (invisibly).
+List or vector containing the results of calling \code{f} on each
+  item in \code{x} (invisibly).
 }
 \description{
 Traverse a Python iterator or generator
+}
+\details{
+Simplification is only attempted all elements are length 1
+ vectors of type "character", "complex", "double", "integer", or
+ "logical".
 }
 


### PR DESCRIPTION
@terrytangyuan I saw that you had an `unlist` call wrapping the results of `iterate` and thought we could automagically eliminate the need to do that in many cases. Take a look and let me know if you think this will present any problems with the way iterators are used in TF.