### PR TITLE
Fix #80 (find PyMalloc libpython)

### DIFF
--- a/R/tf_config.R
+++ b/R/tf_config.R
@@ -87,10 +87,14 @@ tf_python_config <- function(python, python_versions) {
     python_libdir_config <- function(var) {
       python_libdir <- config[[var]]
       ext <- switch(Sys.info()[["sysname"]], Darwin = ".dylib", Windows = ".dll", ".so")
-      libpython <- file.path(python_libdir, paste0("libpython" , version, ext))
+      libpython <- file.path(python_libdir, paste0("libpython" , version, c("", "m"), ext))
+      libpython <- libpython[file.exists(libpython)]
+      if (length(libpython) == 0)
+        return(NA)
+      libpython[1]
     }
     libpython <- python_libdir_config("LIBPL")
-    if (!file.exists(libpython))
+    if (is.na(libpython))
       libpython <- python_libdir_config("LIBDIR")
   }
 


### PR DESCRIPTION
Search for `libpython` now finds libraries of the form `libpython3.5.so`
and `libpython3.5m.so` including the `m` suffix for PyMalloc Python as
per PEP 3149.

In the event that libraries are found with and without the suffix, the
one without is used, so there should be no change for existing
RTensorFlow users with working setups.

Note: [PEP3149](https://www.python.org/dev/peps/pep-3149/) mentions other suffices besides `m`, which I have not addressed (e.g. `u` for wide Unicode support). These could be added too if desired, but I omitted them for now for simplicity.