### PR TITLE
Tensorflow + Windows installation

### DIFF
--- a/R/tf_config.R
+++ b/R/tf_config.R
@@ -67,7 +67,7 @@ tf_discover_config <- function() {
 tf_python_config <- function(python, python_versions) {
 
   # collect configuration information
-  config_script <- system.file("config/config.py", package = "tensorflow")
+  config_script <- paste0("'", system.file("config/config.py", package = "tensorflow"), "'")
   config <- system2(command = python, args = config_script, stdout = TRUE)
   status <- attr(config, "status")
   if (!is.null(status)) {

--- a/R/tf_config.R
+++ b/R/tf_config.R
@@ -67,7 +67,7 @@ tf_discover_config <- function() {
 tf_python_config <- function(python, python_versions) {
 
   # collect configuration information
-  config_script <- paste0("'", system.file("config/config.py", package = "tensorflow"), "'")
+  config_script <- paste0('"', system.file("config/config.py", package = "tensorflow"), '"')
   config <- system2(command = python, args = config_script, stdout = TRUE)
   status <- attr(config, "status")
   if (!is.null(status)) {

--- a/R/tf_config.R
+++ b/R/tf_config.R
@@ -67,7 +67,7 @@ tf_discover_config <- function() {
 tf_python_config <- function(python, python_versions) {
 
   # collect configuration information
-  config_script <- paste0('"', system.file("config/config.py", package = "tensorflow"), '"')
+  config_script <- shQuote(system.file("config/config.py", package = "tensorflow"))
   config <- system2(command = python, args = config_script, stdout = TRUE)
   status <- attr(config, "status")
   if (!is.null(status)) {


### PR DESCRIPTION
Windows installation with config/config.py is not working when the R installation path includes a space. This PR addresses this issue. I am not sure if this is an expected error.

My fix just adds quotes to the `config/config.py` argument when called using `system2`.

My two systems are working.

My first Windows installation (working) is on a clean setup:

* Using Microsoft R 3.3.1, also working in vanilla R
* Get rid of all Anaconda-related stuff in PATH
* Download Python 3.5 here: https://www.python.org/downloads/release/python-352/
* Run in a command prompt `pip install --upgrade https://storage.googleapis.com/tensorflow/windows/cpu/tensorflow-0.12.1-cp35-cp35m-win_amd64.whl` to download Tensorflow and all the associated packages
* Run `devtools::install_github("Laurae2/tensorflow")` to install RStudio's tensorflow package

I got a second installation (working with Anaconda) using Anaconda and Python 3.5:

* Using Microsoft R Client (R 3.3.2)
* Install Anaconda 3.5 here: https://repo.continuum.io/archive/Anaconda3-4.2.0-Windows-x86_64.exe
* Run in a command prompt `pip install tensorflow` to download Tensorflow and all the associated packages
* Run `devtools::install_github("Laurae2/tensorflow")` to install RStudio's tensorflow package

Before this fix, we get the following while installing in R:

```r
** testing if installed package can be loaded
C:\Python35\python.exe: can't open file 'C:/Program': [Errno 2] No such file or directory
Warning: running command '"C:\Python35\python.exe" C:/Program Files/Microsoft/MRO-3.3.1/library/tensorflow/config/config.py' had status 2
Error : .onLoad failed in loadNamespace() for 'tensorflow', details:
  call: tf_python_config(python_version, python_versions)
  error: Error 2 occurred running C:\Python35\python.exe 
Error: loading failed
Execution halted
ERROR: loading failed
* removing 'C:/Program Files/Microsoft/MRO-3.3.1/library/tensorflow'
Error: Command failed (1)
```

After the fix, we get this:

```r
** building package indices
** testing if installed package can be loaded
* DONE (tensorflow)
> library(tensorflow)
> sess = tf$Session()
> hello <- tf$constant('Hello, TensorFlow!')
> sess$run(hello)
b'Hello, TensorFlow!'
```

We can now run Tensorflow stuff in R in Windows!!! (even with Anaconda installation)

I ran the demo here: https://rstudio.github.io/tensorflow/tutorial_mnist_pros.html

At the accuracy check, I got 0.9183 which is in line with the 0.9171 reported on the demo.

```r
> library(tensorflow)
> datasets <- tf$contrib$learn$datasets
> mnist <- datasets$mnist$read_data_sets("MNIST-data", one_hot = TRUE)
> sess <- tf$InteractiveSession()
> x <- tf$placeholder(tf$float32, shape(NULL, 784L))
> y_ <- tf$placeholder(tf$float32, shape(NULL, 10L))
> W <- tf$Variable(tf$zeros(shape(784L, 10L)))
> b <- tf$Variable(tf$zeros(shape(10L)))
> sess$run(tf$global_variables_initializer())
> y <- tf$nn$softmax(tf$matmul(x,W) + b)
> cross_entropy <- tf$reduce_mean(-tf$reduce_sum(y_ * tf$log(y), reduction_indices=1L))
> optimizer <- tf$train$GradientDescentOptimizer(0.5)
> train_step <- optimizer$minimize(cross_entropy)
> for (i in 1:1000) {
+     batches <- mnist$train$next_batch(100L)
+     batch_xs <- batches[[1]]
+     batch_ys <- batches[[2]]
+     sess$run(train_step,
+              feed_dict = dict(x = batch_xs, y_ = batch_ys))
+ }
> correct_prediction <- tf$equal(tf$argmax(y, 1L), tf$argmax(y_, 1L))
> accuracy <- tf$reduce_mean(tf$cast(correct_prediction, tf$float32))
> accuracy$eval(feed_dict=dict(x = mnist$test$images, y_ = mnist$test$labels))
[1] 0.9183
```

I get 0.9194 on Anaconda, still in line with the demo.

P.S: before merging this PR, please check if it does not mess up the installation on Linux. I can't test in Linux right now for some days.

p.s.2: without @jjallaire it would have taken a massive amount of work to have it working in Windows