### PR TITLE
Accepts "Linux" as a supported name in is_ubuntu

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -14,7 +14,7 @@ is_osx <- function() {
 
 is_ubuntu <- function() {
   uname <- suppressWarnings(system2("uname", "--all", stdout = TRUE, stderr = TRUE))
-  grepl("ubuntu", uname[[1]], ignore.case = TRUE)
+  grepl("ubuntu|Linux", uname[[1]], ignore.case = TRUE)
 }
 
 


### PR DESCRIPTION
This is necessary as recent versions of ubuntu use "Linux in uname.