### PR TITLE
Upgrade pip before pip installing tensorflow

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -303,6 +303,20 @@ install_tensorflow_virtualenv <- function(python, virtualenv, version, gpu, pack
     cat("Using existing virtualenv at ", virtualenv_path, "\n")
   }
 
+  # upgrade pip so it can find tensorflow
+  virtualenv_bin <- function(bin) path.expand(file.path(virtualenv_path, "bin", bin))
+  pkgs <- tf_pkgs(version, gpu, package_url)
+  cmd <- sprintf("%ssource %s && %s install --ignore-installed --upgrade %s%s",
+                 ifelse(is_osx(), "", "/bin/bash -c \""),
+                 shQuote(path.expand(virtualenv_bin("activate"))),
+                 shQuote(path.expand(virtualenv_bin(pip_version))),
+                 paste(shQuote(pip_version), collapse = " "),
+                 ifelse(is_osx(), "", "\""))
+  cat("Upgrading pip...\n")
+  result <- system(cmd)
+  if (result != 0L)
+    stop("Error ", result, " occurred updating pip", call. = FALSE)
+
   # install tensorflow and related dependencies
   virtualenv_bin <- function(bin) path.expand(file.path(virtualenv_path, "bin", bin))
   pkgs <- tf_pkgs(version, gpu, package_url)


### PR DESCRIPTION
Old versions of pip fail to locate the tensorflow python package, and old versions of setuptools fail to handle python wheels. This is problematic e.g. in old travis-ci environments with ancient apt versions of pip. To fix this, we `pip install --upgrade pip` and `pip install --upgrade setuptools` before `pip install tensorflow`.

Test status:
- Passes: locally on Linux
- Passed: on travis-ci Linux https://travis-ci.org/nimble-dev/nimble/jobs/248861441
- Passed: on travis-ci OS X https://travis-ci.org/nimble-dev/nimble/jobs/248861446