### PR TITLE
Check the actual Python path during tensorflow_install() 

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -357,12 +357,10 @@ install_tensorflow_windows_system <- function(python, pip, version, gpu, package
 
 
 python_unix_binary <- function(bin) {
-  locations <- file.path(c("/usr/bin", "/usr/local/bin"), bin)
-  locations <- locations[file.exists(locations)]
-  if (length(locations) > 0)
-    locations[[1]]
-  else
-    NULL
+  tryCatch({
+      system2("which", bin, stdout=TRUE, stderr=TRUE)
+    }, warning = function(x){NULL}
+  )
 }
 
 python_version <- function(python) {


### PR DESCRIPTION
The previous method assumes python exists in /usr/bin or
/usr/local/bin which would cause the python_unix_binary()
method to fail if the python to be used lives anywhere else (eg,
local install in the home directory). This change uses the "which"
command to determine the location of the python binary.