### PR TITLE
poll for availability of tensorboard using http rather than stdout

### DIFF
--- a/R/tensorboard.R
+++ b/R/tensorboard.R
@@ -174,15 +174,14 @@ launch_tensorboard <- function(log_dir, host, port, explicit_port, reload_interv
   started <- FALSE
   Sys.sleep(0.25)
   conn <- url(paste0("http://", host, ":", as.character(port)))
+  on.exit(close(conn), add = TRUE)
   while(!started && p$is_alive()) {
     Sys.sleep(0.25)
     tryCatch({
-      readLines(conn, n = -1)
+      suppressWarnings(readLines(conn, n = -1))
       started = TRUE
-      close(conn)
     },
-    error = function(e) {},
-    warning = function(w) {}
+    error = function(e) {}
     )
   }
 


### PR DESCRIPTION
Tensorboard shipped with TensorBoard v1.3 doesn't write a newline at the end of it's output and as a result p$read_output_lines() hangs. This works around that issue by using http to poll for availability of tensorboard.

Tested on Mac, Windows, and Ubuntu with TF v1.2 and 1.3

@kevinushey Could you review this before we merge it?
