### PR TITLE
Hardcoded "pip" as Python package name rather than relying on variable 'pip_version'

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -336,7 +336,7 @@ install_tensorflow_virtualenv <- function(python, virtualenv, version, gpu, pack
   }
 
   # upgrade pip so it can find tensorflow
-  pip_install(pip_version, "Upgrading pip")
+  pip_install("pip", "Upgrading pip")
 
   # install updated version of the wheel package
   pip_install("wheel", "Upgrading wheel")


### PR DESCRIPTION
Earlier I tried installing the R TensorFlow package in a virtualenv on a Linux system with python3 and pip3. Installation failed with:

> Installing setuptools, pip, wheel...done.
> Upgrading pip ...
> Collecting pip3
>   Could not find a version that satisfies the requirement pip3 (from versions: )
> No matching distribution found for pip3
> Error: Error 1 occurred installing TensorFlow

I traced the problem to the fact that when python3 is installed, "pip_version" would be set to "pip3" to be used as a binary name, but was then used as the `pkg` argument when calling `pip_install(pkgs, message)` to install pip in the virtualenv. However, the package name for pip is "pip", not "pip3". 

As the names of the other packages to be installed in the virtualenv are also hardcoded I assume that also harcoding "pip" is a correct fix.