### PR TITLE
don't use r-like extraction from greta

### DIFF
--- a/R/extraction.R
+++ b/R/extraction.R
@@ -1,77 +1,7 @@
-# both options for tensor extraction, mimicing R's behaviour, or using 0-based
-# indexing like python, but without python's R-incompatible syntax (e.g.
-# strides)
 
-unknown_dimension <- function (x) {
-  dims <- dim(x)
-  unknown <- vapply(dims, is.null, FUN.VALUE = FALSE)
-  is.list(dims) && any(unknown)
-}
-
-# tensor extraction mimicing R
-extract_r_like <- function(x, call) {
-
-  dims_in <- dim(x)
-
-  # create a dummy array containing the order of elements Python-style
-  dummy_in <- dummy(dims_in)
-
-  # modify the call and environment to swap dummy_in for the target, and use
-  # primitive subsetting
-  call_list <- as.list(call)[-1]
-  dummy_name <- ".dummy_in"
-  call_list[[1]] <- as.name(dummy_name)
-  env <- as.list(parent.frame(n = 2))
-  env[[dummy_name]] <- dummy_in
-  dummy_out <- with(env, do.call(.Primitive("["), call_list))
-
-  # coerce result to an array
-  dummy_out <- as.array(dummy_out)
-
-  # get number of elements in input and dimension of output
-  nelem <- prod(dims_in)
-  dims_out <- dim(dummy_out)
-  dims_out <- do.call(shape, as.list(dims_out))
-
-  # get the index in flat python format, as a tensor
-  index <- flatten_rowwise(dummy_out)
-
-  # flatten tensor, gather using index, reshape to output dimension
-  tensor_in_flat <- tf$reshape(x, shape(nelem))
-  tf_index <- tf$constant(as.integer(index), dtype = tf$int32)
-  tensor_out_flat <- tf$gather(tensor_in_flat, tf_index)
-  tensor_out <- tf$reshape(tensor_out_flat, dims_out)
-
-  tensor_out
-
-}
-
-# convert an array to a vector row-wise
-flatten_rowwise <- function (array) {
-  dim <- dim(array)
-  array <- aperm(array, rev(seq_along(dim)))
-  dim(array) <- NULL
-  array
-}
-
-# convert an vector to an array row-wise
-unflatten_rowwise <- function (array, dim) {
-  array <- as.array(array)
-  dim(array) <- rev(dim)
-  array <- aperm(array, rev(seq_along(dim)))
-  dim(array) <- dim
-  array
-}
-
-# create an array with the same dimensions as tensor and fill it with
-# consecutive increasing integers in python order
-dummy <- function (dims) {
-  vec <- seq_len(prod(dims)) - 1
-  unflatten_rowwise(vec, dims)
-}
 
 # ~~~~~~
-# tensor extract syntax with zero-based indexing
+# tensor extract syntax with basis 0 or 1
 extract_manual <- function (x, i, j, ..., drop = TRUE, basis = 0) {
 
   # tensor shape as a vector

--- a/R/extraction.R
+++ b/R/extraction.R
@@ -191,16 +191,16 @@ check_zero_based <- function (call) {
                          },
                          FUN.VALUE = FALSE)
 
-  default_r_like <- is.null(getOption("tensorflow.r_like_extract"))
+  default_one_based <- is.null(getOption("tensorflow.one_based_extract"))
 
-  if (any(contain_zero) & default_r_like) {
+  if (any(contain_zero) & default_one_based) {
     warning(paste(
-      "It looks like you might be using 0-based indexing to extract using `[`.",
-      "The tensorflow package now uses 1-based (R-like) indexing by default.\n",
-      "You can switch to the old behavior (0-based indexing) with:",
-      "  options(tensorflow.r_like_extract = FALSE)\n",
+      "It looks like you might be using zero-based indexing to extract using `[`.",
+      "The tensorflow package now uses one-based (R-like) extraction by default.\n",
+      "You can switch to the old behavior (0-based extraction) with:",
+      "  options(tensorflow.one_based_extract = FALSE)\n",
       "If your indexing is as you intend, you can disable this warning with:",
-      "  options(tensorflow.r_like_extract = TRUE)", sep = "\n"
+      "  options(tensorflow.one_based_extract = TRUE)", sep = "\n"
     ), call. = FALSE)
   }
 

--- a/R/extraction.R
+++ b/R/extraction.R
@@ -195,9 +195,9 @@ check_zero_based <- function (call) {
 
   if (any(contain_zero) & default_one_based) {
     warning(paste(
-      "It looks like you might be using zero-based indexing to extract using `[`.",
-      "The tensorflow package now uses one-based (R-like) extraction by default.\n",
-      "You can switch to the old behavior (0-based extraction) with:",
+      "It looks like you might be using 0-based indexing to extract using `[`.",
+      "The tensorflow package now uses 1-based (R-like) extraction by default.\n",
+      "You can switch to the old behavior (1-based extraction) with:",
       "  options(tensorflow.one_based_extract = FALSE)\n",
       "If your indexing is as you intend, you can disable this warning with:",
       "  options(tensorflow.one_based_extract = TRUE)", sep = "\n"

--- a/R/generics.R
+++ b/R/generics.R
@@ -68,25 +68,12 @@ print.tensorflow.python.ops.variables.Variable <- print.tensorflow.python.framew
   check_zero_based(call)
 
   r_like_extract <- getOption("tensorflow.r_like_extract", TRUE)
-  unknown_dim <- unknown_dimension(x)
 
-  if (r_like_extract && !unknown_dim) {
-
-    # if we can, extract exactly as in R
-    extract_r_like(x, call)
-
-  } else {
-
-    # if the indexing is 0-based, or there are missing dimensions, do it
-    # manually
-    basis <- ifelse(r_like_extract, 1, 0)
-    call_list <- as.list(call)[-1]
-    do.call(extract_manual,
-            c(call_list, basis = basis),
-            envir = parent.frame())
-
-  }
-
+  basis <- ifelse(r_like_extract, 1, 0)
+  call_list <- as.list(call)[-1]
+  do.call(extract_manual,
+          c(call_list, basis = basis),
+          envir = parent.frame())
 }
 
 

--- a/R/generics.R
+++ b/R/generics.R
@@ -67,9 +67,9 @@ print.tensorflow.python.ops.variables.Variable <- print.tensorflow.python.framew
   call <- match.call()
   check_zero_based(call)
 
-  r_like_extract <- getOption("tensorflow.r_like_extract", TRUE)
+  one_based_extract <- getOption("tensorflow.one_based_extract", TRUE)
 
-  basis <- ifelse(r_like_extract, 1, 0)
+  basis <- ifelse(one_based_extract, 1, 0)
   call_list <- as.list(call)[-1]
   do.call(extract_manual,
           c(call_list, basis = basis),

--- a/tests/testthat/test-extract-syntax.R
+++ b/tests/testthat/test-extract-syntax.R
@@ -43,68 +43,6 @@ check_expr <- function (expr, name = "x") {
 old_extract_method <- options("tensorflow.r_like_extract")
 options(tensorflow.r_like_extract = NULL)
 
-test_that('extract works like R', {
-
-  skip_if_no_tensorflow()
-
-  a <- randn(10)
-  b <- randn(10, 1)
-  c <- randn(10, 5)
-  d <- randn(2, 2, 2)
-
-  # Can extract with a vector, regardless of dimension
-  check_expr(a[1:6], "a")
-  check_expr(b[1:6], "b")
-  check_expr(c[1:6], "c")
-  check_expr(d[1:6], "d")
-
-  # can extract first column, regardless of dimension
-  check_expr(b[1:6, ], "b")
-  check_expr(b[1:6, 1], "b")
-  check_expr(c[1:6, ], "c")
-  check_expr(c[1:6, 1], "c")
-  check_expr(d[1:2, , ], "d")
-  check_expr(d[1:2, 1, ], "d")
-
-  # can extract with negative dimensions
-  check_expr(a[3:1], "a")
-  check_expr(d[2:1, , 1:2], "d")
-
-  # can extract with logicals
-  check_expr(a[c(TRUE, FALSE, TRUE)], "a")
-
-  # can extract with a mix of numerics and logicals
-  check_expr(d[2:1, , c(TRUE, FALSE)], "d")
-
-  # can extract with missing entries in various places
-  check_expr(d[, , 2:1], "d")
-  check_expr(d[, 2:1, ], "d")
-  check_expr(d[2:1, , ], "d")
-
-  # can extract single elements without dropping dimensions
-  check_expr(d[, , 1], "d")
-  check_expr(d[, 1, ], "d")
-  check_expr(d[1, , ], "d")
-
-  # can do empty extracts
-  check_expr(a[], "a")
-  check_expr(b[], "b")
-  check_expr(c[], "c")
-  check_expr(d[], "d")
-
-  # can do negative extracts
-  check_expr(a[-1], "a")
-  check_expr(b[-(1:3), ], "b")
-  check_expr(c[-(1:4), ], "c")
-  check_expr(d[-(1:2), -1, ], "d")
-
-  # works on containers
-  x <- list(b = tf$constant(b))
-  r_out <- as.array(b[3, 1])
-  tf_out <- grab(x$b[3, 1])
-  expect_identical(r_out, tf_out)
-
-})
 
 # test indexing for unknown dimensions
 
@@ -137,9 +75,6 @@ test_that('extract works for unknown dimensions', {
 
 })
 
-# tests for 0-based indexing
-options(tensorflow.r_like_extract = FALSE)
-
 test_that("scalar indexing works", {
 
   skip_if_no_tensorflow()
@@ -160,9 +95,9 @@ test_that("scalar indexing works", {
   y3_ <- x3_[1, 2, 3]
 
   # extract as Tensors
-  y1 <- x1[0]
-  y2 <- x2[0, 1]
-  y3 <- x3[0, 1, 2]
+  y1 <- x1[1]
+  y2 <- x2[1, 2]
+  y3 <- x3[1, 2, 3]
 
   # they should be equivalent
   expect_equal(y1_, grab(y1))
@@ -170,6 +105,10 @@ test_that("scalar indexing works", {
   expect_equal(y3_, grab(y3))
 
 })
+
+# tests for 0-based indexing
+options(tensorflow.r_like_extract = FALSE)
+
 
 test_that("vector indexing works", {
   skip_if_no_tensorflow()

--- a/tests/testthat/test-extract-syntax.R
+++ b/tests/testthat/test-extract-syntax.R
@@ -40,8 +40,8 @@ check_expr <- function (expr, name = "x") {
 }
 
 # capture previous r-like extraction method, set to default, and return later
-old_extract_method <- options("tensorflow.r_like_extract")
-options(tensorflow.r_like_extract = NULL)
+old_extract_method <- options("tensorflow.one_based_extract")
+options(tensorflow.one_based_extract = NULL)
 
 
 # test indexing for unknown dimensions
@@ -107,7 +107,7 @@ test_that("scalar indexing works", {
 })
 
 # tests for 0-based indexing
-options(tensorflow.r_like_extract = FALSE)
+options(tensorflow.one_based_extract = FALSE)
 
 
 test_that("vector indexing works", {
@@ -335,7 +335,7 @@ test_that("undefined extensions extract", {
 
 })
 
-options(tensorflow.r_like_extract = NULL)
+options(tensorflow.one_based_extract = NULL)
 
 test_that("dim(), length(), nrow(), and ncol() work on tensors", {
 
@@ -361,15 +361,15 @@ test_that('extract warns when indices look 0-based', {
   i1 <- 1:2
 
   # explicit 0-indexing shouldn't warn
-  options(tensorflow.r_like_extract = FALSE)
+  options(tensorflow.one_based_extract = FALSE)
   expect_silent(x[i0, i0])
 
   # explicit 1-indexing shouldn't warn
-  options(tensorflow.r_like_extract = TRUE)
+  options(tensorflow.one_based_extract = TRUE)
   expect_silent(x[i0, i0])
 
   # default 1-indexing should warn only if there's a zero in there
-  options(tensorflow.r_like_extract = NULL)
+  options(tensorflow.one_based_extract = NULL)
   expect_silent(x[i1, i1])
   expect_warning(x[i0, i0],
                  "It looks like you might be using 0-based indexing")
@@ -377,4 +377,4 @@ test_that('extract warns when indices look 0-based', {
 })
 
 # reset user's extract method
-options(tensorflow.r_like_extract = old_extract_method)
+options(tensorflow.one_based_extract = old_extract_method)


### PR DESCRIPTION
@dfalbel pointed out here (https://github.com/rstudio/tensorflow/pull/199#issuecomment-342887212) that the feature complete version of r-like extraction doesn't perform nearly as well as the previous implementation. This PR uses the existing implementation (enhanced to optionally have a 1 rather than 0 basis) rather than the greta implementation.

@goldingn Let me know if this handles things correctly / as you imagined.