### PR TITLE
Additional params and naming for export_savedmodel()

### DIFF
--- a/R/estimator-generics.R
+++ b/R/estimator-generics.R
@@ -62,7 +62,7 @@ train_and_evaluate <- function(object, ...) {
 #' [tfestimators][tfestimators::export_savedmodel.tf_estimator()] packages.
 #'
 #' @param object An \R object.
-#' @param export_dir A string containing a directory in which to export the
+#' @param export_dir_base A string containing a directory in which to export the
 #'   SavedModel.
 #' @param overwrite Should the \code{export_dir} directory be overwritten?
 #' @param versioned Should the model be exported under a versioned subdirectory?
@@ -79,9 +79,7 @@ train_and_evaluate <- function(object, ...) {
 #' @export
 export_savedmodel <- function(
   object,
-  export_dir,
-  overwrite = TRUE,
-  versioned = !overwrite,
+  export_dir_base,
   ...) {
   UseMethod("export_savedmodel")
 }

--- a/R/estimator-generics.R
+++ b/R/estimator-generics.R
@@ -64,8 +64,6 @@ train_and_evaluate <- function(object, ...) {
 #' @param object An \R object.
 #' @param export_dir_base A string containing a directory in which to export the
 #'   SavedModel.
-#' @param overwrite Should the \code{export_dir} directory be overwritten?
-#' @param versioned Should the model be exported under a versioned subdirectory?
 #' @param ... Optional arguments passed on to implementing methods.
 #'
 #' @return The path to the exported directory, as a string.

--- a/R/estimator-generics.R
+++ b/R/estimator-generics.R
@@ -81,7 +81,7 @@ export_savedmodel <- function(
   object,
   export_dir,
   overwrite = TRUE,
-  versioned = FALSE,
+  versioned = !overwrite,
   ...) {
   UseMethod("export_savedmodel")
 }

--- a/R/estimator-generics.R
+++ b/R/estimator-generics.R
@@ -62,8 +62,10 @@ train_and_evaluate <- function(object, ...) {
 #' [tfestimators][tfestimators::export_savedmodel.tf_estimator()] packages.
 #'
 #' @param object An \R object.
-#' @param export_dir_base A string containing a directory in which to create
-#'   versioned subdirectories containing exported SavedModels.
+#' @param export_dir A string containing a directory in which to export the
+#'   SavedModel.
+#' @param overwrite Should the \code{export_dir} directory be overwritten?
+#' @param versioned Should the model be exported under a versioned subdirectory?
 #' @param ... Optional arguments passed on to implementing methods.
 #'
 #' @return The path to the exported directory, as a string.
@@ -75,7 +77,12 @@ train_and_evaluate <- function(object, ...) {
 #'
 #'
 #' @export
-export_savedmodel <- function(object, export_dir_base, ...) {
+export_savedmodel <- function(
+  object,
+  export_dir,
+  overwrite = TRUE,
+  versioned = FALSE,
+  ...) {
   UseMethod("export_savedmodel")
 }
 

--- a/man/export_savedmodel.Rd
+++ b/man/export_savedmodel.Rd
@@ -13,10 +13,6 @@ export_savedmodel(object, export_dir_base, ...)
 SavedModel.}
 
 \item{...}{Optional arguments passed on to implementing methods.}
-
-\item{overwrite}{Should the \code{export_dir} directory be overwritten?}
-
-\item{versioned}{Should the model be exported under a versioned subdirectory?}
 }
 \value{
 The path to the exported directory, as a string.

--- a/man/export_savedmodel.Rd
+++ b/man/export_savedmodel.Rd
@@ -9,10 +9,14 @@ export_savedmodel(object, export_dir_base, ...)
 \arguments{
 \item{object}{An \R object.}
 
-\item{export_dir_base}{A string containing a directory in which to create
-versioned subdirectories containing exported SavedModels.}
+\item{export_dir_base}{A string containing a directory in which to export the
+SavedModel.}
 
 \item{...}{Optional arguments passed on to implementing methods.}
+
+\item{overwrite}{Should the \code{export_dir} directory be overwritten?}
+
+\item{versioned}{Should the model be exported under a versioned subdirectory?}
 }
 \value{
 The path to the exported directory, as a string.


### PR DESCRIPTION
See https://github.com/rstudio/tfdeploy/issues/2. Validated that this change does not break `keras` not `tfestimators` since those functions still handle the old parameter names; however, using the latest `tensorflow` package without upgrading `keras` or `tfestimators` would break this; however, will send PR to each package to depend on devel.