### PR TITLE
Add support to export SavedModels as text

### DIFF
--- a/R/save.R
+++ b/R/save.R
@@ -55,6 +55,7 @@ export_savedmodel.tensorflow.python.client.session.Session <- function(
   outputs,
   overwrite = TRUE,
   versioned = !overwrite,
+  as_text = FALSE,
   ...) {
 
   if (versioned) {
@@ -90,5 +91,5 @@ export_savedmodel.tensorflow.python.client.session.Session <- function(
     signature_def_map = signature
   )
 
-  invisible(builder$save())
+  invisible(builder$save(as_text = as_text))
 }


### PR DESCRIPTION
Add support to export SavedModels models as text. In some corner cases, binary distribution of files might be blocked, say CRAN, attachments, etc. I don't think this change is a must for the upcoming TensorFlow CRAN release.

See also: https://github.com/rstudio/keras/pull/253, support in `tfestimators` is already enabled.