### PR TITLE
error if extraction index has missing values

### DIFF
--- a/R/extraction.R
+++ b/R/extraction.R
@@ -150,12 +150,18 @@ validate_index <- function (x) {
           call. = FALSE)
   }
 
-  if (any(x < 0)) {
-    stop ("negative indexing of Tensors is not currently supported")
-  }
+  negative <- any(x < 0)
 
-  if (x[length(x)] < x[1]) {
-    stop ("decreasing indexing of Tensors is not currently supported",
+  first <- x[1]
+  last <- x[length(x)]
+
+  decreasing <- last < first
+
+  sequential_x <- seq(first, last)
+  non_sequential <- !identical(sequential_x, as.integer(x))
+
+  if (negative | decreasing | non_sequential) {
+    stop ("indices must be sequences of positive, increasing integers with no missing elements",
           call. = FALSE)
   }
 

--- a/R/extraction.R
+++ b/R/extraction.R
@@ -138,30 +138,25 @@ evaluate_index <- function (x, validate = TRUE, n = 3) {
 }
 
 # check the user-specified index is valid
-validate_index <- function (x, base = 0) {
-
-  append <- switch (as.character(base),
-                    `0` = " with 0-based indexing",
-                    `1` = " with unknown dimensions")
+validate_index <- function (x) {
 
   if (!(is.numeric(x) && is.finite(x))) {
     stop ("invalid index - must be numeric and finite",
-          append)
+          call. = FALSE)
   }
 
   if (!(is.vector(x))) {
     stop ("only vector indexing of Tensors is currently supported",
-          append)
+          call. = FALSE)
   }
 
   if (any(x < 0)) {
-    stop ("negative indexing of Tensors is not currently supported",
-          append)
+    stop ("negative indexing of Tensors is not currently supported")
   }
 
   if (x[length(x)] < x[1]) {
     stop ("decreasing indexing of Tensors is not currently supported",
-          append)
+          call. = FALSE)
   }
 
   x

--- a/tests/testthat/test-extract-syntax.R
+++ b/tests/testthat/test-extract-syntax.R
@@ -247,14 +247,14 @@ test_that("negative and decreasing indexing errors", {
 
   # extract with negative indices
   expect_error(x1[-1],
-               'negative indexing of Tensors is not currently supported')
+               'positive')
   expect_error(x2[1:-2, ],
-               'negative indexing of Tensors is not currently supported')
+               'positive')
   # extract with decreasing indices
   expect_error(x1[3:2],
-               'decreasing indexing of Tensors is not currently supported')
+               'increasing integers')
   expect_error(x2[2:1, ],
-               'decreasing indexing of Tensors is not currently supported')
+               'increasing integers')
 
 })
 
@@ -373,6 +373,22 @@ test_that('extract warns when indices look 0-based', {
   expect_silent(x[i1, i1])
   expect_warning(x[i0, i0],
                  "It looks like you might be using 0-based indexing")
+
+})
+
+test_that('extract errors when indices have missing elements', {
+
+  skip_if_no_tensorflow()
+
+  x <- tf$constant(array(0, dim = c(2, 4, 2)))
+
+  # indexing with sequential values shouldn't error
+  x[1, 1:3, ]
+  x[1, c(1, 2, 3), ]
+
+  # indexing with a non-sequential vector should error
+  expect_error( x[1, c(1, 3), ],
+                "no missing elements")
 
 })
 


### PR DESCRIPTION
Makes `[` syntax error if indices aren't what tensorflow expects (#230), and adds a test for that.

You now get:

```r
d <- c(2, 4, 2)
X <- array(seq_len(prod(d)), d)
x <- tf$constant(X)
x[1, c(1, 3), ]
```
> ```
> Error: indices must be sequences of positive, increasing integers with no missing elements 
> ```
This doesn't implement the documentation fix mentioned in that issue.