### PR TITLE
Need to adjust nightly URLs and python3 support in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ before_script:
   - sudo apt-get update
   - sudo apt-get install python3
   - pip install --upgrade --ignore-installed --user travis virtualenv
+  - R -e 'reticulate::py_config()'
   - R CMD INSTALL .
   - R -e 'tensorflow::install_tensorflow(version = Sys.getenv("TENSORFLOW_VERSION"))'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,9 @@ matrix:
       env: "nightly"
 
 before_script:
-  - pip2.7 install --upgrade --ignore-installed --user travis virtualenv
+  - sudo apt-get update
+  - sudo apt-get install python3
+  - pip install --upgrade --ignore-installed --user travis virtualenv
   - R CMD INSTALL .
   - R -e 'tensorflow::install_tensorflow(version = Sys.getenv("TENSORFLOW_VERSION"))'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,14 @@ matrix:
     - name: "1.10"
       env: TENSORFLOW_VERSION="1.10"
     - name: "2.0-preview"
-      env: TENSORFLOW_VERSION="https://files.pythonhosted.org/packages/14/f4/caced52bfdded13e1913c6c6700de847773297d53664666d54cd8f3c06d9/tf_nightly_2.0_preview-1.13.0.dev20190110-cp36-cp36m-manylinux1_x86_64.whl"
+      env: TENSORFLOW_VERSION="https://files.pythonhosted.org/packages/b8/48/983c8af6e63cfeebb6bb89866c38ea7d16491b8f72309f27df41b33a751e/tf_nightly_2.0_preview-1.13.0.dev20190117-cp27-cp27mu-manylinux1_x86_64.whl"
     - env: "nightly"
       name: TENSORFLOW_VERSION="nightly"
   allow_failures:
     - name: "2.0-preview"
-      env: TENSORFLOW_VERSION="https://files.pythonhosted.org/packages/14/f4/caced52bfdded13e1913c6c6700de847773297d53664666d54cd8f3c06d9/tf_nightly_2.0_preview-1.13.0.dev20190110-cp36-cp36m-manylinux1_x86_64.whl"
-    - env: "nightly"
-      name: TENSORFLOW_VERSION="nightly"
+      env: TENSORFLOW_VERSION="https://files.pythonhosted.org/packages/b8/48/983c8af6e63cfeebb6bb89866c38ea7d16491b8f72309f27df41b33a751e/tf_nightly_2.0_preview-1.13.0.dev20190117-cp27-cp27mu-manylinux1_x86_64.whl"
+    - name: TENSORFLOW_VERSION="nightly"
+      env: "nightly"
 
 before_script:
   - pip2.7 install --upgrade --ignore-installed --user travis virtualenv

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,20 +20,21 @@ matrix:
       env: TENSORFLOW_VERSION="1.10"
     - name: "2.0-preview"
       env: TENSORFLOW_VERSION="https://files.pythonhosted.org/packages/b8/48/983c8af6e63cfeebb6bb89866c38ea7d16491b8f72309f27df41b33a751e/tf_nightly_2.0_preview-1.13.0.dev20190117-cp27-cp27mu-manylinux1_x86_64.whl"
-    - env: "nightly"
-      name: TENSORFLOW_VERSION="nightly"
+    - name: "nightly"
+      env:
+        - TENSORFLOW_VERSION="nightly"
+        - TENSORFLOW_PYTHON="/usr/bin/python3"
   allow_failures:
     - name: "2.0-preview"
       env: TENSORFLOW_VERSION="https://files.pythonhosted.org/packages/b8/48/983c8af6e63cfeebb6bb89866c38ea7d16491b8f72309f27df41b33a751e/tf_nightly_2.0_preview-1.13.0.dev20190117-cp27-cp27mu-manylinux1_x86_64.whl"
-    - name: TENSORFLOW_VERSION="nightly"
-      env: "nightly"
+    - name: "nightly"
+      env:
+        - TENSORFLOW_VERSION="nightly"
+        - TENSORFLOW_PYTHON="/usr/bin/python3"
 
 before_script:
   - sudo apt-get update
   - sudo apt-get install python3
   - pip install --upgrade --ignore-installed --user travis virtualenv
-  - which python3
-  - R -e 'reticulate::py_config()'
   - R CMD INSTALL .
   - R -e 'tensorflow::install_tensorflow(version = Sys.getenv("TENSORFLOW_VERSION"))'
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ before_script:
   - sudo apt-get update
   - sudo apt-get install python3
   - pip install --upgrade --ignore-installed --user travis virtualenv
+  - which python3
   - R -e 'reticulate::py_config()'
   - R CMD INSTALL .
   - R -e 'tensorflow::install_tensorflow(version = Sys.getenv("TENSORFLOW_VERSION"))'


### PR DESCRIPTION
Looks like with @skeydan fix we get a clean pass on Travis as well, for the nightly's/1.13 release. TF 2.0 still needs more work.