### PR TITLE
Bugfix/tf 2.0 tests

### DIFF
--- a/R/generics.R
+++ b/R/generics.R
@@ -205,9 +205,9 @@
 "log.tensorflow.tensor" <- function(x, base = exp(1)) {
   if (is_tensor(base) || base != exp(1)) {
     base <- tf$convert_to_tensor(base, x$dtype)
-    tf$log(x) / tf$log(base)
+    tf$math$log(x) / tf$math$log(base)
   } else
-    tf$log(x)
+    tf$math$log(x)
 }
 
 #' @export

--- a/R/save.R
+++ b/R/save.R
@@ -94,10 +94,3 @@ export_savedmodel.tensorflow.python.client.session.Session <- function(
   invisible(builder$save(as_text = as_text))
 }
 
-#' @export
-export_savedmodel.tensorflow.python.keras.engine.training.Model <-
-  function(object, export_dir_base) {
-    tf$saved_model$save(object, export_dir_base)
-  }
-
-

--- a/R/save.R
+++ b/R/save.R
@@ -93,3 +93,11 @@ export_savedmodel.tensorflow.python.client.session.Session <- function(
 
   invisible(builder$save(as_text = as_text))
 }
+
+#' @export
+export_savedmodel.tensorflow.python.keras.engine.training.Model <-
+  function(object, export_dir_base) {
+    tf$saved_model$save(object, export_dir_base)
+  }
+
+

--- a/tests/testthat/test-export-savedmodel.R
+++ b/tests/testthat/test-export-savedmodel.R
@@ -24,10 +24,12 @@ train_mnist_eager <- function() {
     )
   )
 
+  # not needed if this is only entered for TF2 (vs. for eager execution in general)
+  optimizer <- if (tf_v2()) tf$keras$optimizers$Adam() else tf$train$AdamOptimizer()
+
   model$compile(
-    optimizer = "adam",
-    loss = "sparse_categorical_crossentropy",
-    metrics = list("accuracy")
+    optimizer = optimizer,
+    loss = "sparse_categorical_crossentropy"
   )
 
   model$fit(x_train[1:10, , ], y_train[1:10, ], epochs = 1L)
@@ -78,10 +80,10 @@ test_that("export_savedmodel() works with MNIST", {
 
   temp_path <- tempfile()
 
-  if (tf$executing_eagerly()) {
+  if (tf_v2()) {
 
     model <- train_mnist_eager()
-    export_savedmodel(model, temp_path)
+    tf$saved_model$save(model, temp_path)
 
   } else {
 

--- a/tests/testthat/test-export-savedmodel.R
+++ b/tests/testthat/test-export-savedmodel.R
@@ -1,6 +1,42 @@
 context("Save")
 
-train_mnist <- function(sess) {
+
+train_mnist_eager <- function() {
+
+  mnist <- tf$keras$datasets$mnist$load_data()
+  x_train <- mnist[[1]][[1]] / 255
+  y_train <- mnist[[1]][[2]] %>% as.matrix()
+
+  model <- tf$keras$Sequential(
+    list(
+      tf$keras$layers$Reshape(
+        target_shape = c(28L, 28L, 1L),
+        input_shape = c(28L, 28L)
+      ),
+      tf$keras$layers$Conv2D(8L, 5L, padding = "same", activation = tf$nn$relu),
+      tf$keras$layers$MaxPooling2D(c(2, 2), c(2, 2), padding = "same"),
+      tf$keras$layers$Conv2D(16L, 5L, padding = "same", activation = tf$nn$relu),
+      tf$keras$layers$MaxPooling2D(c(2, 2), c(2, 2), padding = "same"),
+      tf$keras$layers$Flatten(),
+      tf$keras$layers$Dense(32L, activation = tf$nn$relu),
+      tf$keras$layers$Dropout(0.4),
+      tf$keras$layers$Dense(10L)
+    )
+  )
+
+  model$compile(
+    optimizer = "adam",
+    loss = "sparse_categorical_crossentropy",
+    metrics = list("accuracy")
+  )
+
+  model$fit(x_train[1:10, , ], y_train[1:10, ], epochs = 1L)
+  model
+
+}
+
+train_mnist_graph <- function(sess) {
+
   datasets <- tf$contrib$learn$datasets
   mnist <- datasets$mnist$read_data_sets("MNIST-data", one_hot = TRUE)
 
@@ -12,7 +48,7 @@ train_mnist <- function(sess) {
   y <- tf$nn$softmax(tf$matmul(x, W) + b)
 
   y_ <- tf$placeholder(tf$float32, shape(NULL, 10L))
-  cross_entropy <- tf$reduce_mean(-tf$reduce_sum(y_ * tf$log(y), reduction_indices=1L))
+  cross_entropy <- tf$reduce_mean(-tf$reduce_sum(y_ * tf$log(y), reduction_indices = 1L))
 
   optimizer <- tf$train$GradientDescentOptimizer(0.5)
   train_step <- optimizer$minimize(cross_entropy)
@@ -32,28 +68,34 @@ train_mnist <- function(sess) {
   correct_prediction <- tf$equal(tf$argmax(y, 1L), tf$argmax(y_, 1L))
   accuracy <- tf$reduce_mean(tf$cast(correct_prediction, tf$float32))
 
-  sess$run(accuracy, feed_dict=dict(x = mnist$test$images, y_ = mnist$test$labels))
+  sess$run(accuracy, feed_dict = dict(x = mnist$test$images, y_ = mnist$test$labels))
 
-  list(
-    input = x,
-    output = y
-  )
+  list(input = x, output = y)
 }
 
-test_that("export_savedmode() works with MNIST", {
-
+test_that("export_savedmodel() works with MNIST", {
   skip_if_no_tensorflow()
 
-  sess <- tf$Session()
-  tensors <- train_mnist(sess)
   temp_path <- tempfile()
 
-  export_savedmodel(
-    sess,
-    temp_path,
-    inputs = list(images = tensors$input),
-    outputs = list(scores = tensors$output)
-  )
+  if (tf$executing_eagerly()) {
+
+    model <- train_mnist_eager()
+    export_savedmodel(model, temp_path)
+
+  } else {
+
+    sess <- tf$Session()
+    tensors <- train_mnist_graph(sess)
+
+    export_savedmodel(
+      sess,
+      temp_path,
+      inputs = list(images = tensors$input),
+      outputs = list(scores = tensors$output)
+    )
+  }
 
   expect_true(file.exists(file.path(temp_path, "saved_model.pb")))
+
 })

--- a/tests/testthat/test-generic-methods.R
+++ b/tests/testthat/test-generic-methods.R
@@ -1,5 +1,7 @@
 context("generic methods")
 
+source("utils.R")
+
 as_tensor <- function(...) tf$convert_to_tensor(...)
 
 expect_near <- function(..., tol = 1e-5) expect_equal(..., tolerance = tol)
@@ -7,12 +9,6 @@ expect_near <- function(..., tol = 1e-5) expect_equal(..., tolerance = tol)
 test_that("log with supplied base works", {
 
   skip_if_no_tensorflow()
-
-  grab <- (function() {
-    sess <- tf$Session()
-    function(x)
-      sess$run(x)
-  })()
 
   r <- array(as.double(1:20))
   t <- as_tensor(r, dtype = tf$float32)
@@ -26,7 +22,7 @@ test_that("log with supplied base works", {
   expect_near(r, grab( log10( 10 ^ t )))
 
   # log() dispatches correctly without trying to change base
-  expect_identical(grab(tf$log(t)), grab(log(t)))
+  expect_identical(grab(tf$math$log(t)), grab(log(t)))
 
   expect_near(log(r), grab(log(t)))
   expect_near(log(r, base = 3), grab(log(t, base = 3)))
@@ -36,12 +32,6 @@ test_that("log with supplied base works", {
 test_that("sinpi dispatches correctly", {
 
   skip_if_no_tensorflow()
-
-  grab <- (function() {
-    sess <- tf$Session()
-    function(x)
-      sess$run(x)
-  })()
 
   r <- array(seq(0, 4, length.out = 100))
   t <- as_tensor(r, dtype = tf$float32)

--- a/tests/testthat/utils.R
+++ b/tests/testthat/utils.R
@@ -1,5 +1,13 @@
-
-
+.SESS <- NULL
+grab <- function(x) {
+  if(tf$executing_eagerly()) {
+    as.array(x)
+  } else {
+    if (is.null(.SESS))
+      .SESS <<- tf$Session()
+    .SESS$run(x)
+  }
+}
 
 skip_if_no_tensorflow <- function() {
   if (!reticulate::py_module_available("tensorflow"))


### PR DESCRIPTION
Tests will run fine if using v1 resp. v2 as they come by default, that is, in non-eager resp. eager modes.

If using v1 and enabling eager,

 _export_savedmodel() works with MNIST_ 

will fail because there won't be a graph. On the other hand, the test has to switch on version, not eager vs. graph, because `tf$saved_model$save` is v2 only.

As this is test code, I think this should be fine...