### PR TITLE
Use example environment variable to configure travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,18 @@ matrix:
     - name: "1.10"
       env: TENSORFLOW_VERSION="1.10"
     - name: "2.0-preview"
-      env: TENSORFLOW_VERSION="https://files.pythonhosted.org/packages/b8/48/983c8af6e63cfeebb6bb89866c38ea7d16491b8f72309f27df41b33a751e/tf_nightly_2.0_preview-1.13.0.dev20190117-cp27-cp27mu-manylinux1_x86_64.whl"
+      env:
+        - TENSORFLOW_VERSION="https://files.pythonhosted.org/packages/b8/48/983c8af6e63cfeebb6bb89866c38ea7d16491b8f72309f27df41b33a751e/tf_nightly_2.0_preview-1.13.0.dev20190117-cp27-cp27mu-manylinux1_x86_64.whl"
+        - TENSORFLOW_TEST_EXAMPLES=""
     - name: "nightly"
       env:
         - TENSORFLOW_VERSION="nightly"
         - TENSORFLOW_PYTHON="/usr/bin/python3"
   allow_failures:
     - name: "2.0-preview"
-      env: TENSORFLOW_VERSION="https://files.pythonhosted.org/packages/b8/48/983c8af6e63cfeebb6bb89866c38ea7d16491b8f72309f27df41b33a751e/tf_nightly_2.0_preview-1.13.0.dev20190117-cp27-cp27mu-manylinux1_x86_64.whl"
+      env:
+        - TENSORFLOW_VERSION="https://files.pythonhosted.org/packages/b8/48/983c8af6e63cfeebb6bb89866c38ea7d16491b8f72309f27df41b33a751e/tf_nightly_2.0_preview-1.13.0.dev20190117-cp27-cp27mu-manylinux1_x86_64.whl"
+        - TENSORFLOW_TEST_EXAMPLES=""
     - name: "nightly"
       env:
         - TENSORFLOW_VERSION="nightly"


### PR DESCRIPTION
Follow up to https://github.com/rstudio/tensorflow/pull/295 to actually make all Travis tests pass for TF 2.0 and TF 1.3.