### PR TITLE
install compatible version of tensorflow-probability

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -74,7 +74,7 @@ install_tensorflow <- function(method = c("auto", "virtualenv", "conda", "system
     extra_packages <- unique(c(extra_packages, "tfp-nightly"))
     extra_packages <- setdiff(extra_packages, "tensorflow-probability")
   }
-  if (substr(version, 1, 4) %in% c("1.12", "1.13")) {
+  if (version == "default" || substr(version, 1, 4) %in% c("1.12", "1.13")) {
     extra_packages <- unique(c(extra_packages, "tensorflow-probability"))
     extra_packages <- setdiff(extra_packages, ("tfp-nightly"))
   }

--- a/R/install.R
+++ b/R/install.R
@@ -71,12 +71,12 @@ install_tensorflow <- function(method = c("auto", "virtualenv", "conda", "system
   # extra packages
   extra_packages <- unique(c(extra_packages, c("keras", "tensorflow-hub")))
   if (version == "nightly") {
-    extra_packages <- unique(c(extra_packages, "tfp-nightly")) %>%
-      setdiff("tensorflow-probability")
+    extra_packages <- unique(c(extra_packages, "tfp-nightly"))
+    extra_packages <- setdiff(extra_packages, "tensorflow-probability")
   }
   if (substr(version, 1, 4) %in% c("1.12", "1.13")) {
-    extra_packages <- unique(c(extra_packages, "tensorflow-probability")) %>%
-      setdiff("tfp-nightly")
+    extra_packages <- unique(c(extra_packages, "tensorflow-probability"))
+    extra_packages <- setdiff(extra_packages, ("tfp-nightly"))
   }
 
   # flags indicating what methods are available

--- a/R/install.R
+++ b/R/install.R
@@ -36,7 +36,7 @@ install_tensorflow <- function(method = c("auto", "virtualenv", "conda", "system
                                conda = "auto",
                                version = "default",
                                envname = "r-tensorflow",
-                               extra_packages = c("keras", "tensorflow-hub"),
+                               extra_packages = NULL,
                                restart_session = TRUE) {
 
   # verify os
@@ -67,6 +67,17 @@ install_tensorflow <- function(method = c("auto", "virtualenv", "conda", "system
   version <- ver$version
   gpu <- ver$gpu
   packages <- ver$packages
+
+  # extra packages
+  extra_packages <- unique(c(extra_packages, c("keras", "tensorflow-hub")))
+  if (version == "nightly") {
+    extra_packages <- unique(c(extra_packages, "tfp-nightly")) %>%
+      setdiff("tensorflow-probability")
+  }
+  if (substr(version, 1, 4) %in% c("1.12", "1.13")) {
+    extra_packages <- unique(c(extra_packages, "tensorflow-probability")) %>%
+      setdiff("tfp-nightly")
+  }
 
   # flags indicating what methods are available
   method_available <- function(name) method %in% c("auto", name)
@@ -527,11 +538,10 @@ parse_tensorflow_version <- function(version) {
   }
 
   # if it's the nightly version then set packages to nightly[-gpu]
-  # (also add tensorboard since it's not included in tf-nightly)
+  # as of 02/15/2019 tf-nightly includes tb-nightly, tf-estimator-nightly
   version <- sub("^tf-nightly$", "nightly", version)
   if (identical(version, "nightly")) {
-    ver$packages <- c(sprintf("tf-nightly%s", ifelse(ver$gpu, "-gpu", "")),
-                      "tensorflow-tensorboard")
+    ver$packages <- c(sprintf("tf-nightly%s", ifelse(ver$gpu, "-gpu", "")))
   }
 
   # return


### PR DESCRIPTION
The requirements according to https://www.tensorflow.org/probability/install are:

- the current TFP release needs a "recent stable release of TensorFlow "
- `tfp-nightly` wants `tf-nightly` 

Testing with conda this yields

1.  when doing `install_tensorflow(version="1.12.0")`

```
(r-tensorflow) ] $ conda list | grep -e tf -e hub -e tb -e tens
# packages in environment at /home/key/anaconda3/envs/r-tensorflow:
tensorboard               1.12.2                    <pip>
tensorflow                1.12.0                    <pip>
tensorflow-hub            0.2.0                     <pip>
tensorflow-probability    0.5.0                     <pip>

```

and 

2. when doing `install_tensorflow(version="nightly")`

```
(r-tensorflow) $ conda list | grep -e tf -e hub -e tb -e tens
# packages in environment at /home/key/anaconda3/envs/r-tensorflow:
tb-nightly                1.13.0a20190214           <pip>
tensorflow-hub            0.2.0                     <pip>
tf-estimator-nightly      1.14.0.dev2019021501           <pip>
tf-nightly                1.13.0.dev20190215           <pip>
tfp-nightly               0.7.0.dev20190215           <pip>
```

Please let me know what you think. 