### PR TITLE
install latest TF release 1.13.1

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -268,7 +268,12 @@ install_tensorflow_conda <- function(conda, version, gpu, envname, packages, ext
 
   # create conda environment
   cat("Creating", envname, "conda environment for TensorFlow installation...\n")
-  python_packages <- "python=3.6" # as of TF v1.9 there are no python 3.7 binaries
+  if (substr(version, 1, 4) == "1.13") {
+    python_packages <- "python=3.7"
+  } else {
+    python_packages <- "python=3.6"
+  }
+
   python <- conda_create(envname, packages = python_packages, conda = conda)
 
 
@@ -506,12 +511,12 @@ parse_tensorflow_version <- function(version) {
   # full url provided
   if (identical(version, "default")) {
 
-    ver$version <- "1.12.0"
+    ver$version <- "1.13.1"
 
   # gpu version
   } else if (identical(version, "gpu")) {
 
-    ver$version <- "1.12.0"
+    ver$version <- "1.13.1"
 
     ver$gpu <- TRUE
 


### PR DESCRIPTION
Strangely, there has never been a release `1.13.0`. 
I have to hard-code `1.13.1` because of this

```
    # workaround the fact that v1.X.1 releases often have no tarball
    version_split <- strsplit(version, ".", fixed = TRUE)[[1]]
    if (length(version_split) > 2 && version_split[[length(version_split)]] != "0")
      version_split <- c(version_split[-length(version_split)], "0")
```

Alternatively, we could check for available versions here, but I don't know if it's worth the overhead.

Still alternatively, I'm just thinking now as I write this - should we "try trusting them" ;-)) and remove the workaround completely? Right now we know there's a 1.13.1 with existing binaries, then it'll be some time till 2.0, and then we'll see?