### PR TITLE
Define TF cpp log level to Warn instead of Info.

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -37,6 +37,11 @@ tf_v2 <- function() {
   if (!is.na(tensorflow_python))
     Sys.setenv(RETICULATE_PYTHON = tensorflow_python)
 
+  # if TF_CPP_MIN_LOG_LEVEL is not defined then >= WARN log level
+  # 1 to filter out INFO logs, 2 to filter out WARNING, 3 to filter out ERROR.
+  Sys.setenv(TF_CPP_MIN_LOG_LEVEL =
+               Sys.getenv("TF_CPP_MIN_LOG_LEVEL", unset = 1))
+
   # delay load tensorflow
   tf <<- import("tensorflow", delay_load = list(
 


### PR DESCRIPTION
By default TF logger has its value set to **WARN**, as can be seen by:

``` r
tf$logging$get_verbosity()
```

    ## [1] 30

``` r
tf$logging$WARN
```

    ## [1] 30

On the other hand, the TF CPP log level is set to **INFO**, resulting in unnecesary logs (this logs appear before every model training):

``` r
sess = tf$Session()
```

``` r
    ## 2019-03-07 11:19:39.340586: I tensorflow/core/platform/cpu_feature_guard.cc:141] Your CPU supports instructions that this TensorFlow binary was not compiled to use: AVX2 FMA
    ## 2019-03-07 11:19:39.425877: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:897] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero
    ## 2019-03-07 11:19:39.426413: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1405] Found device 0 with properties: 
    ## name: GeForce MX150 major: 6 minor: 1 memoryClockRate(GHz): 1.0375
    ## pciBusID: 0000:01:00.0
    ## totalMemory: 1.96GiB freeMemory: 1.72GiB
    ## 2019-03-07 11:19:39.426432: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1484] Adding visible gpu devices: 0
    ## 2019-03-07 11:19:39.656243: I tensorflow/core/common_runtime/gpu/gpu_device.cc:965] Device interconnect StreamExecutor with strength 1 edge matrix:
    ## 2019-03-07 11:19:39.656275: I tensorflow/core/common_runtime/gpu/gpu_device.cc:971]      0 
    ## 2019-03-07 11:19:39.656284: I tensorflow/core/common_runtime/gpu/gpu_device.cc:984] 0:   N 
    ## 2019-03-07 11:19:39.656478: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1097] Created TensorFlow device (/job:localhost/replica:0/task:0/device:GPU:0 with 1476 MB memory) -> physical GPU (device: 0, name: GeForce MX150, pci bus id: 0000:01:00.0, compute capability: 6.1)
```

As a workaround, I always set the `TF_CPP_MIN_LOG_LEVEL` environment variable:

``` bash
export TF_CPP_MIN_LOG_LEVEL="1"
R
```

However, I think it would make more sense to set both TF logging levels to the same value, without losing the functionality of allowing the user to manually set the value of `TF_CPP_MIN_LOG_LEVEL`.