### PR TITLE
Bugfix/install 1.13.1 again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,10 @@ cache:
 matrix:
   include:
     - name: "tf-stable"
-      env: TENSORFLOW_VERSION="1.12"
+      env: TENSORFLOW_VERSION="1.13.1"
     - name: "2.0-preview"
       env:
-        - TENSORFLOW_VERSION="https://files.pythonhosted.org/packages/b8/48/983c8af6e63cfeebb6bb89866c38ea7d16491b8f72309f27df41b33a751e/tf_nightly_2.0_preview-1.13.0.dev20190117-cp27-cp27mu-manylinux1_x86_64.whl"
+        - TENSORFLOW_VERSION="https://files.pythonhosted.org/packages/ba/98/b0b9b83c9eddb9a112e0f928481c78232e1675397ccc717d1dcd92b8544b/tf_nightly_2.0_preview-2.0.0.dev20190319-cp27-cp27mu-manylinux1_x86_64.whl"
         - TENSORFLOW_TEST_EXAMPLES=""
     - name: "nightly"
       env:
@@ -29,7 +29,7 @@ matrix:
   allow_failures:
     - name: "2.0-preview"
       env:
-        - TENSORFLOW_VERSION="https://files.pythonhosted.org/packages/b8/48/983c8af6e63cfeebb6bb89866c38ea7d16491b8f72309f27df41b33a751e/tf_nightly_2.0_preview-1.13.0.dev20190117-cp27-cp27mu-manylinux1_x86_64.whl"
+        - TENSORFLOW_VERSION="https://files.pythonhosted.org/packages/ba/98/b0b9b83c9eddb9a112e0f928481c78232e1675397ccc717d1dcd92b8544b/tf_nightly_2.0_preview-2.0.0.dev20190319-cp27-cp27mu-manylinux1_x86_64.whl"
         - TENSORFLOW_TEST_EXAMPLES=""
     - name: "nightly"
       env:

--- a/R/install.R
+++ b/R/install.R
@@ -511,12 +511,12 @@ parse_tensorflow_version <- function(version) {
   # full url provided
   if (identical(version, "default")) {
 
-    ver$version <- "1.12"
+    ver$version <- "1.13.1"
 
   # gpu version
   } else if (identical(version, "gpu")) {
 
-    ver$version <- "1.12"
+    ver$version <- "1.13.1"
 
     ver$gpu <- TRUE
 


### PR DESCRIPTION
I think we should revert to installing `1.13.1` now that the generator test was fixed.
Also updated the TF 2.0 preview URL.

PR in `keras` to update `travis.yml` follows.