### PR TITLE
Feature/logging option

### DIFF
--- a/R/extract.R
+++ b/R/extract.R
@@ -15,7 +15,7 @@
 #'
 #' x <- tf$constant(1:15, shape = c(3, 5))
 #' sess$run(x)
-#' # by default, numerics supplied to `...` are interperted R style
+#' # by default, numerics supplied to `...` are interpreted R style
 #' sess$run( x[,1] )# first column
 #' sess$run( x[1:2,] ) # first two rows
 #' sess$run( x[,1, drop = FALSE] )
@@ -44,7 +44,7 @@
 #' # tf$newaxis are valid
 #' sess$run( x[,, tf$newaxis] )
 #'
-#' # negative numbers are always interperted python style
+#' # negative numbers are always interpreted python style
 #' # The first time a negative number is supplied to `[`, a warning is issued
 #' # about the non-standard behavior.
 #' sess$run( x[-1,] ) # last row, with a warning
@@ -73,14 +73,14 @@
 #' options(tensorflow.extract.style = NULL)
 #'
 #' # slicing with tensors is valid too, but note, tensors are never
-#' # translated and are always interperted python-style.
+#' # translated and are always interpreted python-style.
 #' # A warning is issued the first time a tensor is passed to `[`
 #' sess$run( x[, tf$constant(0L):tf$constant(2L)] )
 #' # just as in python, only scalar tensors are valid
 #' # https://www.tensorflow.org/api_docs/python/tf/Tensor#__getitem__
 #'
 #' # To silence the warnings about tensors being passed as-is and negative numbers
-#' # being interperted python-style, set
+#' # being interpreted python-style, set
 #' options(tensorflow.extract.style = 'R')
 #'
 #' # clean up from examples

--- a/R/package.R
+++ b/R/package.R
@@ -37,10 +37,11 @@ tf_v2 <- function() {
   if (!is.na(tensorflow_python))
     Sys.setenv(RETICULATE_PYTHON = tensorflow_python)
 
-  # if TF_CPP_MIN_LOG_LEVEL is not defined then >= WARN log level
-  # 1 to filter out INFO logs, 2 to filter out WARNING, 3 to filter out ERROR.
-  Sys.setenv(TF_CPP_MIN_LOG_LEVEL =
-               Sys.getenv("TF_CPP_MIN_LOG_LEVEL", unset = 1))
+  # honor option to silence cpp startup logs (INFO, level 1),
+  # but insist on printing warnings (level 2) and errors (level 3)
+  cpp_log_opt <- getOption("tensorflow.core.cpp_min_log_level")
+  if (!is.null(cpp_log_opt))
+    Sys.setenv(TF_CPP_MIN_LOG_LEVEL = max(min(cpp_log_opt, 1), 0))
 
   # delay load tensorflow
   tf <<- import("tensorflow", delay_load = list(


### PR DESCRIPTION
This effectively enables silencing INFO output only. I guess that could look patronizing but one could argue that if someone for whatever reason wants to disable warnings and errors too, they can  do that in the source and build themselves... Overall I think this is better than having to deal with silenced errors in user issues, should that option be used inadequately...