### PR TITLE
use_compat() in v1 and v2 too

### DIFF
--- a/R/compat.R
+++ b/R/compat.R
@@ -5,9 +5,7 @@
 #' with previous versions. For instance, this is useful to run TensorFlow 1.x
 #' code when using TensorFlow 2.x.
 #'
-#' @inheritParams reticulate py_set_seed
-#'
-#' @param version The version to activate.
+#' @param version The version to activate. Must be `"v1"` or `"v2"`
 #'
 #' @examples
 #' \dontrun{
@@ -16,16 +14,12 @@
 #' }
 #'
 #' @export
-use_compat <- function(version = c("v1")) {
-  if (identical(tf_version(), NULL) || tf_version() < "2.0") return()
+use_compat <- function(version = c("v1", "v2")) {
+  if (identical(tf_version(), NULL)) return()
 
-  # validate method
   version <- match.arg(version)
 
   tf2 <- tf
-
-  # disable eager execution to match v1 default
-  tf2$compat$v1$disable_eager_execution()
 
   unlock <- get("unlockBinding")
   lock <- get("lockBinding")


### PR DESCRIPTION
It's still useful to `use_compat("v1")` even if tensorflow version is 1.14 or 1.15 because it silences deprecation warnings.
Also, I don't think this should change whether or not tensorflow is currently eagerly executing.