### PR TITLE
declare dependency on TensorFlow 2.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,3 +48,9 @@ Imports:
 Roxygen: list(markdown = TRUE)
 Suggests: testthat, keras, tfestimators
 RoxygenNote: 6.1.1
+reticulate@R:
+  list(
+    packages = list(
+      list(package = "tensorflow", version = "2.0.0", pip = TRUE)
+    )
+  )


### PR DESCRIPTION
This allows the new machinery in `reticulate` to auto-install TensorFlow when the `tensorflow` package is loaded.

One question (whose resolution could be hairy): how do we decide between CPU vs. GPU installs of TensorFlow? Is it okay to just use the CPU version always?