### PR TITLE
convert TensorShape to R lists

### DIFF
--- a/R/types.R
+++ b/R/types.R
@@ -13,3 +13,8 @@ shape <- function(...) {
       NULL
   })
 }
+
+#' @export
+py_to_r.tensorflow.python.framework.tensor_shape.TensorShape <- function(x) {
+  reticulate::py_to_r(x$as_list())
+}

--- a/R/types.R
+++ b/R/types.R
@@ -16,5 +16,5 @@ shape <- function(...) {
 
 #' @export
 py_to_r.tensorflow.python.framework.tensor_shape.TensorShape <- function(x) {
-  reticulate::py_to_r(x$as_list())
+  x$as_list()
 }


### PR DESCRIPTION
Shapes a represented as instances of `TensorShape`:

``` r
library(tensorflow)
shape <- tf$TensorShape(list(NULL, 10L))
shape[0]
#> NULL
shape[1]
#> [1] 10
```

This PR will auto convert TensorShapes to lists so we can slice with 1-based indexing.

