### PR TITLE
tf 2.0 doc fix

### DIFF
--- a/R/eager.R
+++ b/R/eager.R
@@ -15,7 +15,7 @@
 #' tfe_enable_eager_execution()
 #'
 #' # create a random 10x10 matrix
-#' x <- tf$random_normal(shape(10, 10))
+#' x <- tf$random$normal(shape(10, 10))
 #'
 #' # use it in R via as.matrix()
 #' heatmap(as.matrix(x))

--- a/R/modules.R
+++ b/R/modules.R
@@ -14,11 +14,8 @@
 #' hello <- tf$constant('Hello, TensorFlow!')
 #' zeros <- tf$Variable(tf$zeros(shape(1L)))
 #'
-#' sess <- tf$Session()
-#' sess$run(tf$global_variables_initializer())
-#'
-#' sess$run(hello)
-#' sess$run(zeros)
+#' tf$print(hello)
+#' tf$print(zeros)
 #' }
 #' @export
 tf <- NULL


### PR DESCRIPTION
Examples in the document are not updated. 
Starting from TF 2.0, we don't need 'session' anymore. 
I change the example codes with TF 2.0 compatibility. 