### PR TITLE
Fixing contrib attribute not found error in tensorflow 2.0

### DIFF
--- a/R/eager.R
+++ b/R/eager.R
@@ -35,7 +35,10 @@
 #' @export
 tfe_enable_eager_execution <- function(
   config = NULL, device_policy = c("explicit", "warn", "silent")) {
-
+  # if eager execution is already running it will throw an error
+  if (tf$executing_eagerly()) {
+    stop('Tensorflow eager execution is already running')
+  }
   # alias eager mode (error if not available in this version of tf)
   contrib <- tf$contrib
   if (py_has_attr(contrib, "eager")) {

--- a/R/eager.R
+++ b/R/eager.R
@@ -15,7 +15,7 @@
 #' tfe_enable_eager_execution()
 #'
 #' # create a random 10x10 matrix
-#' x <- tf$random_normal(shape(10, 10))
+#' x <- tf$random$normal(shape(10, 10))
 #'
 #' # use it in R via as.matrix()
 #' heatmap(as.matrix(x))

--- a/R/modules.R
+++ b/R/modules.R
@@ -14,11 +14,8 @@
 #' hello <- tf$constant('Hello, TensorFlow!')
 #' zeros <- tf$Variable(tf$zeros(shape(1L)))
 #'
-#' sess <- tf$Session()
-#' sess$run(tf$global_variables_initializer())
-#'
-#' sess$run(hello)
-#' sess$run(zeros)
+#' tf$print(hello)
+#' tf$print(zeros)
 #' }
 #' @export
 tf <- NULL


### PR DESCRIPTION
As I mentioned the weird error message in [here](https://github.com/rstudio/tensorflow/issues/394), it throws error message from TensorFlow that it doesn't have the attribute name contrib. I added the stop function with a message that tells the user eager execution is already running. 

Please edit the error message at your convenience. 

Thank you.