### PR TITLE
fix eager execution error

### DIFF
--- a/R/eager.R
+++ b/R/eager.R
@@ -35,6 +35,12 @@
 #' @export
 tfe_enable_eager_execution <- function(
   config = NULL, device_policy = c("explicit", "warn", "silent")) {
+  
+  # if eager execution is already running it will return NULL
+  if (tf$executing_eagerly()) {
+    warning('Tensorflow eager execution is already running')
+    return(NULL)
+  }
 
   # alias eager mode (error if not available in this version of tf)
   contrib <- tf$contrib


### PR DESCRIPTION
Hello members,
I have fixed the eager execution error message. 
It will now return NULL with a warning message about eager execution is already running. (Previously, it looked for the tf.contrib which is not available in TensorFlow 2.0)
Thanks. 