### PR TITLE
Update seed.R

### DIFF
--- a/R/seed.R
+++ b/R/seed.R
@@ -70,7 +70,7 @@ use_session_with_seed <- function(seed,
 
   # disable CUDA if requested
   if (disable_gpu) {
-    Sys.setenv(CUDA_VISIBLE_DEVICES = "")
+    Sys.setenv(CUDA_VISIBLE_DEVICES = "-1")
     disabled <- c(disabled, "GPU")
   }
 


### PR DESCRIPTION
Blank value for CUDA_VISIBLE_DEVICES doesn't really disable GPU in some environments. If anything, it re-enables them if they were already disabled.
Setting it to an invalid ID disables all installed GPUs. 
The same approach is used in TF's examples: https://github.com/tensorflow/tensorflow/blob/81953ff3f0b9f2621794720ee862746bb377f720/tensorflow/lite/testing/generate_examples.py#L40
