### PR TITLE
tf-2.7-compat

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -57,6 +57,7 @@ jobs:
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: 'true'
       R_COMPILE_AND_INSTALL_PACKAGES: 'never'
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - name: Configure RSPM

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,7 @@ Depends: R (>= 3.1)
 Imports:
     config,
     processx,
-    reticulate (> 1.22),
+    reticulate (>= 1.10),
     tfruns (>= 1.0),
     utils,
     yaml,
@@ -51,5 +51,3 @@ Suggests:
     keras,
     callr
 RoxygenNote: 7.1.2
-Remotes:
-    rstudio/reticulate

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,7 @@ Depends: R (>= 3.1)
 Imports:
     config,
     processx,
-    reticulate (>= 1.22-9000),
+    reticulate (> 1.22),
     tfruns (>= 1.0),
     utils,
     yaml,

--- a/NEWS.md
+++ b/NEWS.md
@@ -33,7 +33,7 @@
   Generics that now do autocasting:
     +, -, *, /, %/%, %%, ^, &, |, ==, !=, <, <=, >, >=
 
-- `install_tensorflow()` new argument with default to `pip_ignore_installed = TRUE`. 
+- `install_tensorflow()`: new argument with default `pip_ignore_installed = TRUE`. 
   This ensures that all Tensorflow dependencies like Numpy are installed by pip 
   rather than conda.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,10 @@
   Generics that now do autocasting:
     +, -, *, /, %/%, %%, ^, &, |, ==, !=, <, <=, >, >=
 
+- `install_tensorflow()` new argument with default to `pip_ignore_installed = TRUE`. 
+  This ensures that all Tensorflow dependencies like Numpy are installed by pip 
+  rather than conda.
+
 - A message with the Tensorflow version is now shown when the
   python module is loaded, e.g: "Loaded Tensorflow version 2.6.0"
 

--- a/R/install.R
+++ b/R/install.R
@@ -83,8 +83,7 @@
 #'   with the prebuilt TensorFlow binaries.
 #'
 #' @param ... other arguments passed to [reticulate::conda_install()] or
-#'   [reticulate::virtualenv_install()], depending on the `method` used. Accepts
-#'   `pip_ignore_installed=TRUE`.
+#'   [reticulate::virtualenv_install()], depending on the `method` used.
 #'
 #' @seealso [`keras::install_keras()`]
 #'

--- a/R/install.R
+++ b/R/install.R
@@ -92,6 +92,7 @@ install_tensorflow <- function(method = c("auto", "virtualenv", "conda"),
                                restart_session = TRUE,
                                conda_python_version = "3.7",
                                ...,
+                               pip_ignore_installed = TRUE,
                                python_version = conda_python_version) {
 
   # verify 64-bit
@@ -144,6 +145,7 @@ install_tensorflow <- function(method = c("auto", "virtualenv", "conda"),
     conda          = conda,
     python_version = python_version,
     pip            = TRUE,
+    pip_ignore_installed = pip_ignore_installed,
     ...
   )
 

--- a/R/install.R
+++ b/R/install.R
@@ -86,7 +86,7 @@
 #'   [reticulate::virtualenv_install()], depending on the `method` used. Accepts
 #'   `pip_ignore_installed=TRUE`.
 #'
-#' @seealso keras::install_keras()
+#' @seealso [`keras::install_keras()`]
 #'
 #' @export
 install_tensorflow <- function(method = c("auto", "virtualenv", "conda"),

--- a/R/install.R
+++ b/R/install.R
@@ -77,9 +77,14 @@
 #'   the created conda environment. Ignored when attempting to install with a
 #'   Python virtual environment.
 #'
+#' @param pip_ignore_installed Whether pip should ignore installed python
+#'   packages and reinstall all already installed python packages. This defaults
+#'   to `TRUE`, to ensure that TensorFlow dependencies like NumPy are compatible
+#'   with the prebuilt TensorFlow binaries.
+#'
 #' @param ... other arguments passed to [reticulate::conda_install()] or
-#'   [reticulate::virtualenv_install()], depending on the `method` used.
-#'   Accepts `pip_ignore_installed=TRUE`.
+#'   [reticulate::virtualenv_install()], depending on the `method` used. Accepts
+#'   `pip_ignore_installed=TRUE`.
 #'
 #' @seealso keras::install_keras()
 #'

--- a/man/install_tensorflow.Rd
+++ b/man/install_tensorflow.Rd
@@ -57,9 +57,9 @@ only occur within RStudio).}
 \code{pip_ignore_installed=TRUE}.}
 
 \item{pip_ignore_installed}{Whether pip should ignore installed python
-packages and reinstall any already installed packages. This defaults to \code{TRUE},
-to ensure that TensorFlow dependencies like NumPy are compatible with
-the prebuilt TensorFlow binaries.}
+packages and reinstall all already installed python packages. This defaults
+to \code{TRUE}, to ensure that TensorFlow dependencies like NumPy are compatible
+with the prebuilt TensorFlow binaries.}
 
 \item{python_version, conda_python_version}{the python version installed in
 the created conda environment. Ignored when attempting to install with a
@@ -120,5 +120,5 @@ for details.
 }
 
 \seealso{
-keras::install_keras()
+\code{\link[keras:install_keras]{keras::install_keras()}}
 }

--- a/man/install_tensorflow.Rd
+++ b/man/install_tensorflow.Rd
@@ -53,8 +53,13 @@ TensorFlow.}
 only occur within RStudio).}
 
 \item{...}{other arguments passed to \code{\link[reticulate:conda-tools]{reticulate::conda_install()}} or
-\code{\link[reticulate:virtualenv-tools]{reticulate::virtualenv_install()}}, depending on the \code{method} used.
-Accepts \code{pip_ignore_installed=TRUE}.}
+\code{\link[reticulate:virtualenv-tools]{reticulate::virtualenv_install()}}, depending on the \code{method} used. Accepts
+\code{pip_ignore_installed=TRUE}.}
+
+\item{pip_ignore_installed}{Whether pip should ignore installed python
+packages and reinstall any already installed packages. This defaults to \code{TRUE},
+to ensure that TensorFlow dependencies like NumPy are compatible with
+the prebuilt TensorFlow binaries.}
 
 \item{python_version, conda_python_version}{the python version installed in
 the created conda environment. Ignored when attempting to install with a

--- a/man/install_tensorflow.Rd
+++ b/man/install_tensorflow.Rd
@@ -13,6 +13,7 @@ install_tensorflow(
   restart_session = TRUE,
   conda_python_version = "3.7",
   ...,
+  pip_ignore_installed = TRUE,
   python_version = conda_python_version
 )
 }
@@ -28,7 +29,7 @@ available on Windows.}
 
 \item{version}{TensorFlow version to install. Valid values include:
 \itemize{
-\item \code{"default"} installs  2.6
+\item \code{"default"} installs  2.7
 \item \code{"release"} installs the latest release version of tensorflow (which may
 be incompatible with the current version of the R package)
 \item A version specification like \code{"2.4"} or \code{"2.4.0"}. Note that if the patch


### PR DESCRIPTION
Changed default in `install_tensorflow()` to use `pip_ignore_installed=TRUE`. 

This is because otherwise, Numpy would be installed from the conda channel, and the Numpy provided by conda is incompatible with the tensorflow package that is installed from pip. This error would present on MacOS: 

```
 ImportError: 

IMPORTANT: PLEASE READ THIS FOR ADVICE ON HOW TO SOLVE THIS ISSUE!

Importing the numpy C-extensions failed. This error can happen for
many reasons, often due to issues with your setup or how NumPy was
installed.

We have compiled some common reasons and troubleshooting tips at:

    https://numpy.org/devdocs/user/troubleshooting-importerror.html

Please note and check the following:

  * The Python version is: Python3.7 from "/Users/tomasz/Library/r-miniconda/envs/r-reticulate/bin/python"
  * The NumPy version is: "1.21.2"

and make sure that they are the versions you expect.
Please carefully study the documentation linked above for further help.

Original error was: dlopen(/Users/tomasz/Library/r-miniconda/envs/r-reticulate/lib/python3.7/site-packages/numpy/core/_mul
Execution halted
```