### PR TITLE
Generic method fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,7 @@ Depends: R (>= 3.6)
 Imports:
     config,
     processx,
-    reticulate (>= 1.31),
+    reticulate (>= 1.31.0.9000),
     tfruns (>= 1.0),
     utils,
     yaml,
@@ -53,3 +53,5 @@ Suggests:
     pillar,
     callr
 RoxygenNote: 7.2.3
+Remotes:  
+    rstudio/reticulate

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # tensorflow (development version)
 
+- `install_tensorflow()` installs the "tensorflow-metal" package on arm macs
+- Fixed an issue where `as.array()` and other methods might fail if the tensor
+  had conversion disabled via `r_to_py()` or `convert = FALSE`.
+- Fixed an issue where Ops group generic dispatch would error one object was a tensor
+  and the other was a non-tensor Python object.
+
 # tensorflow 2.13.0
 
 - `install_tensorflow()` changes:

--- a/R/eager.R
+++ b/R/eager.R
@@ -4,7 +4,7 @@
 as.array.python.builtin.EagerTensor <- function(x, ...) {
   if (py_is_null_xptr(x))
     return(NULL)
-  if(x$dtype$name == "string")
+  if(as_r_value(x$dtype$name) == "string")
     array(as.character(x, ...),
           dim = if(length(dx <- dim(x))) dx else 1L)
   else
@@ -130,7 +130,7 @@ as.character.tensorflow.python.ops.variables.Variable <-
 #' @importFrom grDevices as.raster
 #' @export
 as.raster.python.builtin.EagerTensor <-
-function(x, max = if(x$dtype$is_integer) x$dtype$max else 1, ...)
+function(x, max = if(as_r_value(x$dtype$is_integer)) as_r_value(x$dtype$max) else 1, ...)
   as.raster(as.array(x), max = max, ...)
 
 #' @export

--- a/R/eager.R
+++ b/R/eager.R
@@ -8,7 +8,7 @@ as.array.python.builtin.EagerTensor <- function(x, ...) {
     array(as.character(x, ...),
           dim = if(length(dx <- dim(x))) dx else 1L)
   else
-    x$numpy()
+    as_r_value(x$numpy())
 }
 
 #' @export
@@ -107,7 +107,7 @@ as.logical.tensorflow.python.ops.variables.Variable <- as.logical.python.builtin
 
 #' @export
 as.character.python.builtin.EagerTensor <- function(x, ...) {
-  out <- x$numpy()
+  out <- as_r_value(x$numpy())
   # as.character() on python bytes dispatches to
   # reticulate:::as.character.python.builtin.bytes, which calls
   # x$decode(encoding = "utf-8", errors = "strict")

--- a/tests/testthat/test-generic-methods.R
+++ b/tests/testthat/test-generic-methods.R
@@ -307,3 +307,26 @@ for (x in xx) {
   test_generic("as.vector", x)
 }
 
+
+test_that("generics can handle tensors w/ convert=FALSE", {
+
+  skip_if_no_tensorflow()
+
+  # this tests that `*` dispatches correctly even of both x and y provide Ops methods
+  x <- tf$ones(shape(5, 5)) * r_to_py(array(1, dim = c(5, 5)))
+  expect_true(as.logical(all(x == 1)))
+
+  # test that as.array / as.raster can work even if convert=FALSE
+  img <- tf$random$uniform(shape(256, 256, 4), maxval = 256) |>
+    tf$cast("int8")
+  x <- np_array(array(c(2, 1, 1, 1), dim = c(1, 1, 4)), dtype = "int8") # convert=FALSE
+
+  expect_no_error(as.raster(img))
+  expect_no_error(as.raster(img %/% x))
+  expect_no_error(as.raster(r_to_py(img %/% x)))
+  expect_no_error(as.raster(r_to_py(r_to_py(img) %/% x)))
+  expect_no_error(as.raster(r_to_py(img %/% r_to_py(x))))
+
+})
+
+


### PR DESCRIPTION
Fixes two issues:

1) Ops dispatch failing, as described in https://github.com/rstudio/reticulate/pull/1452
2) `as.array()` and others methods that build on it like `as.raster()`, failing if the tensor was created with `convert = FALSE`. 