### PR TITLE
fix `install_tensorflow(version = "2.17.0-rc0")`

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -336,8 +336,11 @@ parse_tensorflow_version <- function(version) {
   if(version %in% c("default", ""))
     version <- default_version
 
+  if(nchar(gsub("[^.]", "", version)) < 2L)
+    version <- paste0(version, ".*")
+
   if(!grepl("[><=]", version))
-    version <- sprintf("==%s.*", version)
+    version <- sprintf("==%s", version)
 
   paste0(package, version)
 }


### PR DESCRIPTION
Fixed issue where we would incorrectly add a `.*` suffix to an already fully qualified version string.