### PR TITLE
Use `py_require()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,7 @@ Depends: R (>= 3.6)
 Imports:
     config,
     processx,
-    reticulate (>= 1.32),
+    reticulate (>= 1.40.0.9000),
     tfruns (>= 1.0),
     utils,
     yaml,
@@ -55,3 +55,5 @@ Suggests:
     withr,
     callr
 RoxygenNote: 7.3.2
+Remotes:  
+    rstudio/reticulate

--- a/R/install.R
+++ b/R/install.R
@@ -336,7 +336,7 @@ has_gpu <- function() {
 
 
 get_py_requirements <- function() {
-  python_version <- ">=3.9,<=3.12"
+  python_version <- ">=3.9,<3.13"
   packages <- "tensorflow"
 
   if(is_linux()) {
@@ -352,7 +352,7 @@ get_py_requirements <- function() {
     use_gpu <- FALSE
     if (use_gpu) {
       packages <- c("tensorflow-macos", "tensorflow-metal")
-      python_version <- ">=3.9,<=3.11"
+      python_version <- ">=3.9,<3.12"
     }
 
   } else if (is_windows()) {

--- a/R/install.R
+++ b/R/install.R
@@ -309,7 +309,7 @@ has_gpu <- function() {
   has_nvidia_gpu <- function() {
     lspci_listed <- tryCatch(
       as.logical(length(
-        system("lspci | grep -i nvidia", intern = TRUE)
+        system("lspci | grep -i nvidia", intern = TRUE, ignore.stderr = TRUE)
       )),
       # warning emitted by system for non-0 exit status
       warning = function(w) FALSE,
@@ -321,7 +321,7 @@ has_gpu <- function() {
 
     # lspci doens't list GPUs on WSL Linux, but nvidia-smi does.
     nvidia_smi_listed <- tryCatch(
-      system("nvidia-smi -L", intern = TRUE),
+      system("nvidia-smi -L", intern = TRUE, ignore.stderr = TRUE),
       warning = function(w) character(),
       error = function(e) character()
     )

--- a/R/install.R
+++ b/R/install.R
@@ -336,7 +336,7 @@ has_gpu <- function() {
 
 
 get_py_requirements <- function() {
-  python_version <- ">=3.10"
+  python_version <- ">=3.9,<=3.12"
   packages <- "tensorflow"
 
   if(is_linux()) {

--- a/R/package.R
+++ b/R/package.R
@@ -215,7 +215,7 @@ print.tensorflow_config <- function(x, ...) {
   if (x$available) {
     aliased <- function(path) sub(Sys.getenv("HOME"), "~", path)
     cat("TensorFlow v", x$version_str, " (", aliased(x$location), ")\n", sep = "")
-    cat("Python v", x$python_version, " (", aliased(x$python), ")\n", sep = "")
+    cat("Python v", as.character(x$python_version), " (", aliased(x$python), ")\n", sep = "")
   } else {
     cat(x$error_message, "\n")
   }

--- a/R/package.R
+++ b/R/package.R
@@ -51,6 +51,10 @@ tf_v2 <- function() {
   if (!is.null(cpp_log_opt))
     Sys.setenv(TF_CPP_MIN_LOG_LEVEL = max(min(cpp_log_opt, 3), 0))
 
+  # register requirements with py_require()
+  reqs <- get_py_requirements()
+  reticulate::py_require(reqs$packages, reqs$python_version)
+
   # delay load tensorflow
   tryCatch({
 

--- a/tensorflow.Rproj
+++ b/tensorflow.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 9b7991ac-25ac-456a-aa6e-b7af13061228
 
 RestoreWorkspace: No
 SaveWorkspace: No


### PR DESCRIPTION
This approach removes the need for users to call `install_tensorflow()`.