### PR TITLE
Don't install `tensorflow-metal` by default (again)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -97,9 +97,12 @@ jobs:
 
       - name: Install TensorFlow
         run: |
+          print(sessionInfo())
+          print(Sys.info())
           version <- '${{ matrix.tf }}'
           if (version != "default")
             tensorflow::install_tensorflow(version = '${{ matrix.tf }}')
+          tensorflow::tf_config()
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -96,7 +96,10 @@ jobs:
           upgrade: 'TRUE'
 
       - name: Install TensorFlow
-        run: tensorflow::install_tensorflow(version = '${{ matrix.tf }}')
+        run: |
+          version <- '${{ matrix.tf }}'
+          if (version != "default")
+            tensorflow::install_tensorflow(version = '${{ matrix.tf }}')
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,11 +3,11 @@
 - Updates for reticulate 1.41. The tensorflow R package now calls
   `reticuate::py_require()` when it is loaded. Calling `install_tensorflow()`
   in most circumstances is no longer necessary.
-- GPU usage on M-series Macs is once again enabled by default.
 - `install_tensorflow()` installs TensorFlow v2.18 by default.
 - Fixed an issue where GPUs would not be found when running on Windows
   WSL Linux (reported in rstudio/keras3#1456, fixed in #599)
 - Fixes for NumPy 2.0 (#601)
+- Fixes for R-devel (4.5)
 
 # tensorflow 2.16.0
 

--- a/R/install.R
+++ b/R/install.R
@@ -20,9 +20,11 @@
 #' if `tensorflow-metal` is installed. There are known issues with random number
 #' generators like `tf$random$stateless_uniform()`, likely others as well.
 #'
-#' - On Windows: `"tensorflow"` is declared. Note that TensorFlow GPU usage on
-#' Windows is no longer supported (Since TensorFlow 2.10). To use a GPU on
-#' windows, use TensorFlow via WSL.
+#' - On Windows: `"tensorflow"` and `"numpy<2"` are declared. Note that
+#' TensorFlow GPU usage on Windows is no longer supported (Since TensorFlow
+#' 2.10). To use a GPU on windows, use TensorFlow via WSL. `"numpy<2"` is
+#' declared because at the time of this publishing, the pre-built binaries of
+#' `tensorflow` for Windows are not compatible with `numpy>2`.
 #'
 #' `install_tensorflow()` creates a new virtual environment containing the
 #' `tensorflow` python package and it's direct dependencies. For creating a

--- a/R/install.R
+++ b/R/install.R
@@ -1,6 +1,7 @@
 #' Install TensorFlow and its dependencies
 #'
 #' @description
+#'
 #' Beginning with reticulate version 1.41, in most circumstances, calling the
 #' `install_tensorflow()` function is no longer necessary, because reticulate
 #' automatically registers python requirements with `reticulate::py_require()`
@@ -12,13 +13,16 @@
 #' - On Linux: if a GPU is detected: `"tensorflow[and-cuda]"`, otherwise,
 #' `"tensorflow-cpu"`.
 #'
-#' - On macOS: `c("tensorflow", "tensorflow-metal")`. To prevent TensorFlow usage of
-#' the GPU, call `reticulate::py_require("tensorflow-metal", action = "remove")`
-#' before reticulate has initialized Python.
+#' - On macOS: `"tensorflow"` is declared. The default package is not capable
+#' of using the GPU. To enable TensorFlow usage of the GPU, call
+#' `reticulate::py_require("tensorflow-metal")` before reticulate has
+#' initialized Python. Note that not all features of TensorFlow work correctly
+#' if `tensorflow-metal` is installed. There are known issues with random number
+#' generators like `tf$random$stateless_uniform()`, likely others as well.
 #'
 #' - On Windows: `"tensorflow"` is declared. Note that TensorFlow GPU usage on
-#' Windows is no longer supported. To use a GPU on windows, use TensorFlow via
-#' WSL.
+#' Windows is no longer supported (Since TensorFlow 2.10). To use a GPU on
+#' windows, use TensorFlow via WSL.
 #'
 #' `install_tensorflow()` creates a new virtual environment containing the
 #' `tensorflow` python package and it's direct dependencies. For creating a

--- a/R/install.R
+++ b/R/install.R
@@ -371,8 +371,8 @@ get_py_requirements <- function() {
 
   } else if (is_mac_arm64()) {
 
-    use_gpu <- TRUE
-    # https://pypi.org/project/tensorflow-metal/1.2.0/#history
+    use_gpu <- FALSE
+    # https://pypi.org/project/tensorflow-metal/#history
     # https://pypi.org/project/tensorflow-macos/#history
     if (use_gpu) {
       packages <- c("tensorflow", "tensorflow-metal")

--- a/R/install.R
+++ b/R/install.R
@@ -384,6 +384,8 @@ get_py_requirements <- function() {
 
   } else if (is_windows()) {
 
+    packages <- c(packages, "numpy<2")
+
   }
 
   list(packages = packages, python_version = python_version)

--- a/man/install_tensorflow.Rd
+++ b/man/install_tensorflow.Rd
@@ -94,12 +94,15 @@ package:
 \itemize{
 \item On Linux: if a GPU is detected: \code{"tensorflow[and-cuda]"}, otherwise,
 \code{"tensorflow-cpu"}.
-\item On macOS: \code{c("tensorflow", "tensorflow-metal")}. To prevent TensorFlow usage of
-the GPU, call \code{reticulate::py_require("tensorflow-metal", action = "remove")}
-before reticulate has initialized Python.
+\item On macOS: \code{"tensorflow"} is declared. The default package is not capable
+of using the GPU. To enable TensorFlow usage of the GPU, call
+\code{reticulate::py_require("tensorflow-metal")} before reticulate has
+initialized Python. Note that not all features of TensorFlow work correctly
+if \code{tensorflow-metal} is installed. There are known issues with random number
+generators like \code{tf$random$stateless_uniform()}, likely others as well.
 \item On Windows: \code{"tensorflow"} is declared. Note that TensorFlow GPU usage on
-Windows is no longer supported. To use a GPU on windows, use TensorFlow via
-WSL.
+Windows is no longer supported (Since TensorFlow 2.10). To use a GPU on
+windows, use TensorFlow via WSL.
 }
 
 \code{install_tensorflow()} creates a new virtual environment containing the

--- a/man/install_tensorflow.Rd
+++ b/man/install_tensorflow.Rd
@@ -100,9 +100,11 @@ of using the GPU. To enable TensorFlow usage of the GPU, call
 initialized Python. Note that not all features of TensorFlow work correctly
 if \code{tensorflow-metal} is installed. There are known issues with random number
 generators like \code{tf$random$stateless_uniform()}, likely others as well.
-\item On Windows: \code{"tensorflow"} is declared. Note that TensorFlow GPU usage on
-Windows is no longer supported (Since TensorFlow 2.10). To use a GPU on
-windows, use TensorFlow via WSL.
+\item On Windows: \code{"tensorflow"} and \code{"numpy<2"} are declared. Note that
+TensorFlow GPU usage on Windows is no longer supported (Since TensorFlow
+2.10). To use a GPU on windows, use TensorFlow via WSL. \code{"numpy<2"} is
+declared because at the time of this publishing, the pre-built binaries of
+\code{tensorflow} for Windows are not compatible with \code{numpy>2}.
 }
 
 \code{install_tensorflow()} creates a new virtual environment containing the

--- a/tests/testthat/test-types.R
+++ b/tests/testthat/test-types.R
@@ -12,3 +12,18 @@ test_that("TensorShapes are not converted to lists", {
   expect_true(y[2] == shape(10))
   expect_identical(y[[2]], 10L)
 })
+
+
+test_that("tf.random works", {
+  # Installing tensorflow-metal 1.2.0 makes this error.
+  x <- tf$random$stateless_uniform(
+    shape = tuple(10L),
+    seed = tuple(2L, 3L),
+    minval = 0L,
+    maxval = 10L,
+    dtype = tf$dtypes$int32)
+  expect_s3_class(x, "tensorflow.tensor")
+  x <- as.array(x)
+  expect_type(x, "integer")
+  expect_identical(dim(x), 10L)
+})

--- a/tests/testthat/test-types.R
+++ b/tests/testthat/test-types.R
@@ -24,6 +24,7 @@ test_that("tf.random works", {
     dtype = tf$dtypes$int32)
   expect_s3_class(x, "tensorflow.tensor")
   x <- as.array(x)
-  expect_type(x, "integer")
+  if (!is_windows())
+    expect_type(x, "integer")
   expect_identical(dim(x), 10L)
 })


### PR DESCRIPTION
On macOS, don't install `tensorflow-metal` by default (again), because it causes errors in our test suite (e.g., simple `tf.random.stateless_unfirom()` calls error).

On Windows, require `numpy<2`, because it appears the `2.18.0` build of `tensorflow-intel` requires it in practice. (Again, tests fail without it). It's likely that the `numpy<2` constraint can be removed next release.