### PR TITLE
Fix tensorboard() with newer TensorBoard versions

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -20,3 +20,6 @@ MNIST-data
 ^cran-comments\.md$
 ^CRAN-SUBMISSION$
 ^revdep$
+^\.positai$
+^\.claude$
+^\.codex$

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ MNIST-data
 issues/
 logs
 revdep
+.positai

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # tensorflow (development version)
 
+- Updated docs to recommend `py_require_tensorflow()` for TensorFlow setup (#627).
+- Fixed `tensorboard()` startup with recent TensorBoard versions (#626).
+
 # tensorflow 2.20.0
 
 - Updates for reticulate 1.41 and `reticuate::py_require()`. 

--- a/R/tensorboard.R
+++ b/R/tensorboard.R
@@ -142,7 +142,7 @@ tensorboard <- function(log_dir, action = c("start", "stop"),
 
 tensorboard_version <- function() {
   if (is.null(ver <- .globals$tensorboard_version)) {
-    ver <- package_version(system("tensorboard --version_tb", intern = TRUE, ignore.stderr = TRUE))
+    ver <- package_version(system("tensorboard --version", intern = TRUE, ignore.stderr = TRUE))
     .globals$tensorboard_version <- ver
   }
   ver

--- a/R/tensorboard.R
+++ b/R/tensorboard.R
@@ -149,6 +149,17 @@ tensorboard_version <- function() {
 }
 
 
+tensorboard_python_warnings <- function() {
+  filter <- "ignore:pkg_resources is deprecated as an API:UserWarning:tensorboard.default"
+  warnings <- Sys.getenv("PYTHONWARNINGS", unset = "")
+
+  if (nzchar(warnings))
+    paste(warnings, filter, sep = ",")
+  else
+    filter
+}
+
+
 launch_tensorboard <- function(log_dir, host, port, explicit_port, reload_interval, purge_orphaned_data) {
 
   if (tensorboard_version() < "2.0") {
@@ -172,7 +183,8 @@ launch_tensorboard <- function(log_dir, host, port, explicit_port, reload_interv
                                "--port", as.character(port),
                                "--reload_interval", as.integer(reload_interval),
                                "--purge_orphaned_data", purge_orphaned_data),
-                             stdout = "|", stderr = "|")
+                             stdout = "|", stderr = "|",
+                             env = c("current", PYTHONWARNINGS = tensorboard_python_warnings()))
 
   # poll for availability of the http server (continue as long as the
   # process is still alive). note that we used to poll for stdout however
@@ -202,21 +214,10 @@ launch_tensorboard <- function(log_dir, host, port, explicit_port, reload_interv
     err <- p$read_error_lines()
 
     # write it unless it's a port in use error when we are auto-binding
-    if (explicit_port || !any(grepl(paste0("^.*", port, ".*already in use.*$"), err)))
+    if (length(err) && (explicit_port || !any(grepl(paste0("^.*", port, ".*already in use.*$"), err))))
       write(err, stderr())
   }
 
   # return the process
   p
 }
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
## Summary

Closes #626.

Newer TensorBoard releases no longer support `tensorboard --version_tb`, which makes `tensorflow::tensorboard()` fail while detecting the TensorBoard version. This updates version detection to use `tensorboard --version`.

The PR also scopes a `PYTHONWARNINGS` filter to the spawned TensorBoard process to suppress TensorBoard's `pkg_resources` startup deprecation warning without changing warning behavior in the parent R session.

## Public-facing changes

- `tensorflow::tensorboard()` works with newer TensorBoard versions that removed `--version_tb`.

## Internal-only changes

- Adds a small helper for TensorBoard subprocess warning filters.
- Avoids writing empty stderr output after TensorBoard startup.
- Ignores local agent metadata directories in package/build ignore files.

## Testing

- `devtools::load_all(); testthat::test_dir("tests/testthat")`
- Real `tensorboard()` launch with TensorBoard 2.20.0
